### PR TITLE
적절하지 못했던 예외처리 수정

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/error/exception/AlreadyRegisteredFavoriteException.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/error/exception/AlreadyRegisteredFavoriteException.java
@@ -1,6 +1,0 @@
-package kr.reciptopia.reciptopiaserver.domain.error.exception;
-
-public class AlreadyRegisteredFavoriteException extends
-    RuntimeException {
-
-}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/error/exception/AlreadyRegisteredHistoryException.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/error/exception/AlreadyRegisteredHistoryException.java
@@ -1,6 +1,0 @@
-package kr.reciptopia.reciptopiaserver.domain.error.exception;
-
-public class AlreadyRegisteredHistoryException extends
-    RuntimeException {
-
-}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/Account.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/Account.java
@@ -15,8 +15,6 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import kr.reciptopia.reciptopiaserver.domain.error.exception.AlreadyRegisteredFavoriteException;
-import kr.reciptopia.reciptopiaserver.domain.error.exception.AlreadyRegisteredHistoryException;
 import kr.reciptopia.reciptopiaserver.domain.error.exception.BoardNotFoundException;
 import kr.reciptopia.reciptopiaserver.domain.error.exception.CommentNotFoundException;
 import kr.reciptopia.reciptopiaserver.domain.error.exception.FavoriteNotFoundException;
@@ -170,11 +168,8 @@ public class Account extends TimeEntity {
     }
 
     public void addFavorite(Favorite favorite) {
-        Account favoriteOwner = favorite.getOwner();
-        if (favoriteOwner != null && !favoriteOwner.equals(this))
-            throw new AlreadyRegisteredFavoriteException();
         favorites.add(favorite);
-        if (!this.equals(favoriteOwner)) {
+        if (!this.equals(favorite.getOwner())) {
             favorite.setOwner(this);
         }
     }
@@ -187,11 +182,8 @@ public class Account extends TimeEntity {
     }
 
     public void addHistory(History history) {
-        Account historyOwner = history.getOwner();
-        if (historyOwner != null && !historyOwner.equals(this))
-            throw new AlreadyRegisteredHistoryException();
         histories.add(history);
-        if (!this.equals(historyOwner)) {
+        if (!this.equals(history.getOwner())) {
             history.setOwner(this);
         }
     }


### PR DESCRIPTION
이미 `owner`가 존재하는 `History`와 `Favorite`를 새로운 `Account`에 추가할 경우, 기존 예외를 던지는 방식에서 기존의 `owner`와 관계를 끊고 새로운 `Account`와 관계를 맺도록 수정