### PR TITLE
Reply에서 LikeTag에 관한 부적절한 관계편의 메소드 수정

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/Reply.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/Reply.java
@@ -77,8 +77,8 @@ public class Reply {
 
 	public void addLikeTag(LikeTag liketag) {
 		likes.add(likeTag);
-		if (!this.equals(likeTag.getOwner())) {
-			likeTag.setOwner(this);
+		if (!this.equals(likeTag.getReply())) {
+			likeTag.setReply(this);
 		}
 	}
 
@@ -87,8 +87,8 @@ public class Reply {
 			throw new LikeTagNotFoundException();
 
 		likes.remove(likeTag);
-		if (this.equals(likeTag.getOwner())) {
-			likeTag.setOwner(null);
+		if (this.equals(likeTag.getReply())) {
+			likeTag.setReply(null);
 		}
 	}
 }


### PR DESCRIPTION
`Reply`의 `LikeTag`에 관한 관계편의 메소드 `addLikeTag`, `removeLikeTag` 수정
close #30