### PR TITLE
PostDto에 record, Singular 어노테이션 적용

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
 	public Result create(Create dto, Authentication authentication) {
 		Post post = dto.asEntity();
 
-		Account dtoOwner = repoHelper.findAccountOrThrow(dto.getOwnerId());
+		Account dtoOwner = repoHelper.findAccountOrThrow(dto.ownerId());
 		authorizer.requireByOneself(authentication, dtoOwner);
 
 		post.setOwner(dtoOwner);
@@ -74,14 +74,14 @@ public class PostService {
 		Post entity = repoHelper.findPostOrThrow(id);
 		authorizer.requireByOneself(authentication, entity.getOwner());
 
-		if (dto.getPictureUrls() != null) {
-			entity.setPictureUrls(dto.getPictureUrls());
+		if (dto.pictureUrls() != null) {
+			entity.setPictureUrls(dto.pictureUrls());
 		}
-		if (dto.getTitle() != null) {
-			entity.setTitle(dto.getTitle());
+		if (dto.title() != null) {
+			entity.setTitle(dto.title());
 		}
-		if (dto.getContent() != null) {
-			entity.setContent(dto.getContent());
+		if (dto.content() != null) {
+			entity.setContent(dto.content());
 		}
 
 		return Result.of(postRepository.save(entity));

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/PostDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/PostDto.java
@@ -2,7 +2,6 @@ package kr.reciptopia.reciptopiaserver.domain.dto;
 
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Singular;
 import lombok.With;
 import org.springframework.data.util.Streamable;
@@ -14,70 +13,82 @@ import java.util.stream.Collectors;
 
 public interface PostDto {
 
-	@Data
-	@Builder
 	@With
-	class Create {
+	record Create(Long ownerId, Long recipeId,
+				  List<String> pictureUrls, String title, String content) {
 
-		@NotNull
-		private Long ownerId;
+		@Builder
+		public Create(
+				@NotNull
+						Long ownerId,
 
-		@NotNull
-		private Long recipeId;
+				@NotNull
+						Long recipeId,
 
-		@Singular
-		private List<String> pictureUrls;
+				@Singular
+						List<String> pictureUrls,
 
-		@NotEmpty
-		private String title;
+				@NotEmpty
+						String title,
 
-		private String content;
+				String content) {
+			this.ownerId = ownerId;
+			this.recipeId = recipeId;
+			this.pictureUrls = pictureUrls;
+			this.title = title;
+			this.content = content;
+		}
 
 		public Post asEntity() {
 			return Post.builder()
-					.pictureUrls(pictureUrls)
 					.title(title)
 					.content(content)
+					.pictureUrls(pictureUrls)
 					.build();
 		}
 	}
 
-	@Data
-	@Builder
 	@With
-	class Update {
+	record Update(String title, String content, List<String> pictureUrls) {
 
-		@Singular
-		private List<String> pictureUrls;
+		@Builder
+		public Update(
+				@NotEmpty
+						String title,
 
-		@NotEmpty
-		private String title;
+				String content,
 
-		private String content;
+				@Singular
+						List<String> pictureUrls) {
+			this.title = title;
+			this.content = content;
+			this.pictureUrls = pictureUrls;
+		}
 	}
 
-	@Data
-	@Builder
 	@With
-	class Result {
+	record Result(
+			@NotNull
+			Long id,
 
-		@NotNull
-		private Long id;
+			@NotNull
+			Long ownerId,
 
-		@NotNull
-		private Long ownerId;
+			@NotNull
+			Long recipeId,
 
-		@NotNull
-		private Long recipeId;
+			List<String> pictureUrls,
 
-		private List<String> pictureUrls;
+			@NotEmpty
+			String title,
 
-		@NotEmpty
-		private String title;
+			String content,
 
-		private String content;
+			Long views) {
 
-		private Long views;
+		@Builder
+		public Result {
+		}
 
 		public static Result of(Post entity) {
 			return Result.builder()


### PR DESCRIPTION
- 인텔리제이와 lombok 플러그인 호환성 이슈 발생
- `PostDto`를 `record` 적용하여 변경
- 컬렉션 필드인 `pictureUrls`에 직접 `Singular` 어노테이션 적용하지 않고,
   Builder의 파라미터에 `Singular` 어노테이션 적용