### PR TITLE
Authorizer 세분화

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/AccountService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/AccountService.java
@@ -7,13 +7,13 @@ import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Update;
 
 import java.util.List;
-import kr.reciptopia.reciptopiaserver.business.service.authorizer.AbstractAuthorizer;
+import kr.reciptopia.reciptopiaserver.business.service.authorizer.AccountAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
 import kr.reciptopia.reciptopiaserver.domain.model.UserRole;
 import kr.reciptopia.reciptopiaserver.persistence.repository.AccountRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -24,26 +24,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AccountService {
 
     private final PasswordEncoder passwordEncoder;
     private final AccountRepository accountRepository;
     private final RepositoryHelper repoHelper;
     private final ServiceErrorHelper errorHelper;
-    private final AbstractAuthorizer authorizer;
-
-    @Autowired
-    public AccountService(PasswordEncoder passwordEncoder,
-        AccountRepository accountRepository,
-        RepositoryHelper repoHelper,
-        ServiceErrorHelper errorHelper,
-        AbstractAuthorizer authorizer) {
-        this.passwordEncoder = passwordEncoder;
-        this.accountRepository = accountRepository;
-        this.repoHelper = repoHelper;
-        this.errorHelper = errorHelper;
-        this.authorizer = authorizer;
-    }
+    private final AccountAuthorizer accountAuthorizer;
 
     @Transactional
     public Result create(Create dto) {
@@ -68,7 +56,7 @@ public class AccountService {
     @Transactional
     public Result update(Long id, Update dto, Authentication authentication) {
         Account entity = repoHelper.findAccountOrThrow(id);
-        authorizer.requireByOneself(authentication, entity);
+        accountAuthorizer.requireByOneself(authentication, entity);
 
         if (dto.email() != null) {
             entity.setEmail(dto.email());
@@ -89,7 +77,7 @@ public class AccountService {
     @Transactional
     public void delete(Long id, Authentication authentication) {
         Account account = repoHelper.findAccountOrThrow(id);
-        authorizer.requireByOneself(authentication, account);
+        accountAuthorizer.requireByOneself(authentication, account);
         account.removeAllCollections();
 
         accountRepository.delete(account);

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/AbstractAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/AbstractAuthorizer.java
@@ -3,13 +3,14 @@ package kr.reciptopia.reciptopiaserver.business.service.authorizer;
 
 import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import lombok.AllArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Component;
 
-@Component
-public record AbstractAuthorizer(
-    AuthenticationInspector authInspector,
-    ServiceErrorHelper errorHelper) {
+@AllArgsConstructor
+public class AbstractAuthorizer {
+
+    protected final AuthenticationInspector authInspector;
+    protected final ServiceErrorHelper errorHelper;
 
     public void requireByOneself(Authentication authentication, Account requester) {
         if (authInspector.isAdmin(authentication))

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/AccountAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/AccountAuthorizer.java
@@ -1,0 +1,15 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountAuthorizer extends AbstractAuthorizer {
+
+    public AccountAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/CommentAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/CommentAuthorizer.java
@@ -1,0 +1,28 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.domain.model.Comment;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentAuthorizer extends AbstractAuthorizer {
+
+    public CommentAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+    public void requireCommentOwner(Authentication authentication, Comment requestedComment) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (account != requestedComment.getOwner()) {
+            throw errorHelper.forbidden("Not the owner of the comment");
+        }
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/IngredientAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/IngredientAuthorizer.java
@@ -1,0 +1,29 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.domain.model.Ingredient;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IngredientAuthorizer extends RecipeAuthorizer {
+
+    public IngredientAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+    public <T extends Ingredient> void requireIngredientOwner(Authentication authentication,
+        T requestedIngredient) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (account != requestedIngredient.getRecipe().getPost().getOwner()) {
+            throw errorHelper.forbidden("Not the owner of the ingredient");
+        }
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/PostAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/PostAuthorizer.java
@@ -1,0 +1,28 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.domain.model.Post;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostAuthorizer extends AbstractAuthorizer {
+
+    public PostAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+    public void requirePostOwner(Authentication authentication, Post requestedPost) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (account != requestedPost.getOwner()) {
+            throw errorHelper.forbidden("Not the owner of the post");
+        }
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/RecipeAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/RecipeAuthorizer.java
@@ -1,0 +1,28 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecipeAuthorizer extends PostAuthorizer {
+
+    public RecipeAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+    public void requireRecipeOwner(Authentication authentication, Recipe requestedRecipe) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (account != requestedRecipe.getPost().getOwner()) {
+            throw errorHelper.forbidden("Not the owner of the recipe");
+        }
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/StepAuthorizer.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/authorizer/StepAuthorizer.java
@@ -1,0 +1,28 @@
+package kr.reciptopia.reciptopiaserver.business.service.authorizer;
+
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.domain.model.Step;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StepAuthorizer extends RecipeAuthorizer {
+
+    public StepAuthorizer(
+        AuthenticationInspector authInspector,
+        ServiceErrorHelper errorHelper) {
+        super(authInspector, errorHelper);
+    }
+
+    public void requireStepOwner(Authentication authentication, Step requestedStep) {
+        if (authInspector.isAdmin(authentication))
+            return;
+        Account account = authInspector.getAccountOrThrow(authentication);
+
+        if (account != requestedStep.getRecipe().getPost().getOwner()) {
+            throw errorHelper.forbidden("Not the owner of the step");
+        }
+    }
+
+}


### PR DESCRIPTION
`Authorizer`에 `Account`를 입력해야 하는것이 아니라, `Authorizer`가 `Account`를 찾도록 `Authorizer`클래스로써 기능을 확대하는 방향이 SOLID의 단일책임 원칙에 좀 더 부합하는 방향이라 판단

close #84 