### PR TITLE
AuthHelper 세분화

### DIFF
--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -30,11 +30,11 @@ import kr.reciptopia.reciptopiaserver.docs.ApiDocumentation;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import kr.reciptopia.reciptopiaserver.domain.model.UserRole;
-import kr.reciptopia.reciptopiaserver.helper.AuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.EntityHelper;
 import kr.reciptopia.reciptopiaserver.helper.JsonHelper;
 import kr.reciptopia.reciptopiaserver.helper.Struct;
 import kr.reciptopia.reciptopiaserver.helper.TransactionHelper;
+import kr.reciptopia.reciptopiaserver.helper.auth.AccountAuthHelper;
 import kr.reciptopia.reciptopiaserver.persistence.repository.AccountRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.PostRepository;
 import kr.reciptopia.reciptopiaserver.util.H2DbCleaner;
@@ -95,7 +95,7 @@ public class AccountIntegrationTest {
     private EntityHelper entityHelper;
 
     @Autowired
-    private AuthHelper authHelper;
+    private AccountAuthHelper accountAuthHelper;
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -299,7 +299,7 @@ public class AccountIntegrationTest {
                         .withRole(UserRole.USER)
                 );
 
-                String token = authHelper.generateToken(account);
+                String token = accountAuthHelper.generateToken(account);
                 return new Struct()
                     .withValue("token", token)
                     .withValue("id", account.getId());
@@ -369,7 +369,7 @@ public class AccountIntegrationTest {
             Struct given = trxHelper.doInTransaction(() -> {
 
                 Post post = entityHelper.generatePost();
-                String token = authHelper.generateToken(post.getOwner());
+                String token = accountAuthHelper.generateToken(post.getOwner());
                 return new Struct()
                     .withValue("token", token)
                     .withValue("postId", post.getId())
@@ -430,7 +430,7 @@ public class AccountIntegrationTest {
             Struct given = trxHelper.doInTransaction(() -> {
 
                 Account account = entityHelper.generateAccount();
-                String token = authHelper.generateToken(account);
+                String token = accountAuthHelper.generateToken(account);
                 return new Struct()
                     .withValue("token", token)
                     .withValue("id", account.getId());
@@ -469,7 +469,7 @@ public class AccountIntegrationTest {
             Struct given = trxHelper.doInTransaction(() -> {
 
                 Post post = entityHelper.generatePost();
-                String token = authHelper.generateToken(post.getOwner());
+                String token = accountAuthHelper.generateToken(post.getOwner());
                 return new Struct()
                     .withValue("token", token)
                     .withValue("postId", post.getId())

--- a/src/test/java/kr/reciptopia/reciptopiaserver/CommentIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/CommentIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import kr.reciptopia.reciptopiaserver.docs.ApiDocumentation;
@@ -28,11 +29,11 @@ import kr.reciptopia.reciptopiaserver.domain.dto.CommentDto.Update;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
 import kr.reciptopia.reciptopiaserver.domain.model.Comment;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
-import kr.reciptopia.reciptopiaserver.helper.AuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.EntityHelper;
 import kr.reciptopia.reciptopiaserver.helper.JsonHelper;
 import kr.reciptopia.reciptopiaserver.helper.Struct;
 import kr.reciptopia.reciptopiaserver.helper.TransactionHelper;
+import kr.reciptopia.reciptopiaserver.helper.auth.CommentAuthHelper;
 import kr.reciptopia.reciptopiaserver.persistence.repository.CommentRepository;
 import kr.reciptopia.reciptopiaserver.util.H2DbCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +87,7 @@ public class CommentIntegrationTest {
     private EntityHelper entityHelper;
 
     @Autowired
-    private AuthHelper authHelper;
+    private CommentAuthHelper commentAuthHelper;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext,
@@ -107,7 +108,7 @@ public class CommentIntegrationTest {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
                 Account account = entityHelper.generateAccount();
-                String token = authHelper.generateToken(account);
+                String token = commentAuthHelper.generateToken(account);
                 Post post = entityHelper.generatePost();
 
                 return new Struct()
@@ -292,7 +293,7 @@ public class CommentIntegrationTest {
                     it.withContent("테스트 댓글 내용")
                 );
 
-                String token = authHelper.generateToken(comment.getOwner());
+                String token = commentAuthHelper.generateToken(comment.getOwner());
                 return new Struct()
                     .withValue("token", token)
                     .withValue("id", comment.getId());
@@ -348,7 +349,7 @@ public class CommentIntegrationTest {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {
                 Comment comment = entityHelper.generateComment();
-                String token = authHelper.generateToken(comment.getOwner());
+                String token = commentAuthHelper.generateToken(comment.getOwner());
                 return new Struct()
                     .withValue("token", token)
                     .withValue("id", comment.getId());

--- a/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
@@ -27,11 +27,11 @@ import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Create;
 import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Update;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
-import kr.reciptopia.reciptopiaserver.helper.AuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.EntityHelper;
 import kr.reciptopia.reciptopiaserver.helper.JsonHelper;
 import kr.reciptopia.reciptopiaserver.helper.Struct;
 import kr.reciptopia.reciptopiaserver.helper.TransactionHelper;
+import kr.reciptopia.reciptopiaserver.helper.auth.PostAuthHelper;
 import kr.reciptopia.reciptopiaserver.persistence.repository.PostRepository;
 import kr.reciptopia.reciptopiaserver.util.H2DbCleaner;
 import org.junit.jupiter.api.BeforeEach;
@@ -88,7 +88,7 @@ public class PostIntegrationTest {
     private EntityHelper entityHelper;
 
     @Autowired
-    private AuthHelper authHelper;
+    private PostAuthHelper postAuthHelper;
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -113,7 +113,7 @@ public class PostIntegrationTest {
             Struct given = trxHelper.doInTransaction(() -> {
                 Account account = entityHelper.generateAccount();
 
-                String token = authHelper.generateToken(account);
+                String token = postAuthHelper.generateToken(account);
                 return new Struct()
                     .withValue("token", token)
                     .withValue("id", account.getId());
@@ -321,7 +321,7 @@ public class PostIntegrationTest {
                         .withPictureUrl("C:\\Users\\eunsung\\Desktop\\temp\\picture")
                         .withPictureUrl("C:\\Users\\tellang\\Desktop\\temp\\picture")
                 );
-                String token = authHelper.generateToken(post.getOwner());
+                String token = postAuthHelper.generateToken(post.getOwner());
 
                 return new Struct()
                     .withValue("token", token)
@@ -397,7 +397,7 @@ public class PostIntegrationTest {
                         .withPictureUrl("C:\\Users\\eunsung\\Desktop\\temp\\picture")
                         .withPictureUrl("C:\\Users\\tellang\\Desktop\\temp\\picture")
                 );
-                String token = authHelper.generateToken(post.getOwner());
+                String token = postAuthHelper.generateToken(post.getOwner());
 
                 return new Struct()
                     .withValue("token", token)

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
@@ -1,0 +1,51 @@
+package kr.reciptopia.reciptopiaserver.helper;
+
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Result;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
+
+import kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto;
+import kr.reciptopia.reciptopiaserver.domain.model.MainIngredient;
+
+public class MainIngredientHelper {
+
+    public static MainIngredient aMainIngredient() {
+        MainIngredient entitiy = MainIngredient.builder()
+            .build();
+        entitiy.setId(0L);
+        return entitiy;
+    }
+
+    public static Create aMainIngredientCreateDto() {
+        return Create.builder()
+            .build();
+    }
+
+    public static Update aMainIngredientUpdateDto() {
+        return Update.builder()
+            .build();
+    }
+
+    public static Result aMainIngredientResultDto() {
+        return Result.builder()
+            .build();
+    }
+
+    public interface Bulk {
+
+        static MainIngredientDto.Bulk.Create aMainIngredientCreateDto() {
+            return MainIngredientDto.Bulk.Create.builder()
+                .build();
+        }
+
+        static MainIngredientDto.Bulk.Update aMainIngredientUpdateDto() {
+            return MainIngredientDto.Bulk.Update.builder()
+                .build();
+        }
+
+        static MainIngredientDto.Bulk.Result aMainIngredientResultDto() {
+            return MainIngredientDto.Bulk.Result.builder()
+                .build();
+        }
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/AccountAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/AccountAuthHelper.java
@@ -1,0 +1,12 @@
+package kr.reciptopia.reciptopiaserver.helper.auth;
+
+import kr.reciptopia.reciptopiaserver.business.service.JwtService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountAuthHelper extends AuthHelper {
+
+    public AccountAuthHelper(JwtService jwtService) {
+        super(jwtService);
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/AuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/AuthHelper.java
@@ -1,12 +1,14 @@
-package kr.reciptopia.reciptopiaserver.helper;
+package kr.reciptopia.reciptopiaserver.helper.auth;
 
 
 import kr.reciptopia.reciptopiaserver.business.service.JwtService;
 import kr.reciptopia.reciptopiaserver.domain.model.Account;
-import org.springframework.stereotype.Component;
+import lombok.AllArgsConstructor;
 
-@Component
-public record AuthHelper(JwtService jwtService) {
+@AllArgsConstructor
+public class AuthHelper {
+
+    protected final JwtService jwtService;
 
     public String generateToken(Account account) {
         return jwtService.signJwt(account);

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/CommentAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/CommentAuthHelper.java
@@ -1,0 +1,17 @@
+package kr.reciptopia.reciptopiaserver.helper.auth;
+
+import kr.reciptopia.reciptopiaserver.business.service.JwtService;
+import kr.reciptopia.reciptopiaserver.domain.model.Comment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentAuthHelper extends AuthHelper {
+
+    public CommentAuthHelper(JwtService jwtService) {
+        super(jwtService);
+    }
+
+    public String generateToken(Comment comment) {
+        return generateToken(comment.getOwner());
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/PostAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/PostAuthHelper.java
@@ -1,0 +1,17 @@
+package kr.reciptopia.reciptopiaserver.helper.auth;
+
+import kr.reciptopia.reciptopiaserver.business.service.JwtService;
+import kr.reciptopia.reciptopiaserver.domain.model.Post;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostAuthHelper extends AuthHelper {
+
+    public PostAuthHelper(JwtService jwtService) {
+        super(jwtService);
+    }
+
+    public String generateToken(Post post) {
+        return generateToken(post.getOwner());
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/RecipeAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/RecipeAuthHelper.java
@@ -1,0 +1,18 @@
+package kr.reciptopia.reciptopiaserver.helper.auth;
+
+
+import kr.reciptopia.reciptopiaserver.business.service.JwtService;
+import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RecipeAuthHelper extends PostAuthHelper {
+
+    public RecipeAuthHelper(JwtService jwtService) {
+        super(jwtService);
+    }
+
+    public String generateToken(Recipe recipe) {
+        return generateToken(recipe.getPost());
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/StepAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/StepAuthHelper.java
@@ -1,0 +1,17 @@
+package kr.reciptopia.reciptopiaserver.helper.auth;
+
+import kr.reciptopia.reciptopiaserver.business.service.JwtService;
+import kr.reciptopia.reciptopiaserver.domain.model.Step;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StepAuthHelper extends RecipeAuthHelper {
+
+    public StepAuthHelper(JwtService jwtService) {
+        super(jwtService);
+    }
+
+    public String generateToken(Step step) {
+        return generateToken(step.getRecipe());
+    }
+}


### PR DESCRIPTION
`AuthHelper`에 `Account`를 입력해야 하는것이 아니라, `AuthHelper`가 `Account`를 찾도록 `AuthHelper`클래스로써 기능을 확대하는 방향이 SOLID의 단일책임 원칙에 좀 더 부합하는 방향이라 판단

close #83 