### PR TITLE
Account API 통합 테스트 항목 추가

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/SearchHistory.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/model/SearchHistory.java
@@ -47,6 +47,8 @@ public class SearchHistory extends TimeEntity {
 
     @Singular
     @ElementCollection(fetch = LAZY)
+    @JoinColumn(name = "search_history_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Set<String> ingredientNames = new HashSet<>();
 
     @Builder

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -578,6 +578,46 @@ public class AccountIntegrationTest {
         }
 
         @Test
+        void Comment들이_있는_Account_삭제(
+            @Autowired CommentRepository commentRepository,
+            @Autowired CommentAuthHelper commentAuthHelper
+        ) throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+
+                Account owner = entityHelper.generateAccount();
+                Comment commentA = entityHelper.generateComment(it -> it
+                    .withOwner(owner));
+                Comment commentB = entityHelper.generateComment(it -> it
+                    .withOwner(owner));
+
+                String token = commentAuthHelper.generateToken(commentA);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentAId", commentA.getId())
+                    .withValue("commentBId", commentB.getId())
+                    .withValue("ownerId", owner.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentAId = given.valueOf("commentAId");
+            Long commentBId = given.valueOf("commentBId");
+            Long ownerId = given.valueOf("ownerId");
+
+            // When
+            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
+                .header("Authorization", "Bearer " + token));
+
+            // Then
+            actions
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(emptyString()));
+
+            assertThat(repository.findById(ownerId)).isEmpty();
+            assertThat(commentRepository.findById(commentAId)).isEmpty();
+            assertThat(commentRepository.findById(commentBId)).isEmpty();
+        }
+
+        @Test
         void Reply가_있는_Account_삭제(
             @Autowired ReplyRepository replyRepository,
             @Autowired CommentRepository commentRepository,


### PR DESCRIPTION
- 연관관계 추가에 따른 테스트 케이스 추가
- 다중 연관관계에 대한 테스트 케이스 추가
- ElementCollection의 관계에서 삭제에 대한 Cascade가 전파되지 않는 문제
  - [관련 리포트](https://hibernate.atlassian.net/browse/HHH-5529)