### PR TITLE
Post API 통합 테스트 항목 추가

### DIFF
--- a/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
@@ -638,7 +638,7 @@ public class PostIntegrationTest {
         }
 
         @Test
-        void Favorite들에_추가되어__있는_Post_삭제(
+        void Favorite들에_추가되어_있는_Post_삭제(
             @Autowired FavoriteRepository favoriteRepository
         ) throws Exception {
             // Given


### PR DESCRIPTION
- 연관관계 추가에 따른 테스트 케이스 추가
- 다중 연관관계에 대한 테스트 케이스 추가
- `Post`를 삭제할때 해당 `Post`의 소유자의 `Account`가 삭제되지 않음을 확인하는 검증 코드 추가