### PR TITLE
Recipe API 통합 테스트 항목 추가

### DIFF
--- a/src/test/java/kr/reciptopia/reciptopiaserver/RecipeIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/RecipeIntegrationTest.java
@@ -316,7 +316,7 @@ public class RecipeIntegrationTest {
         }
 
         @Test
-        void Step가_있는_Recipe_삭제(
+        void Step이_있는_Recipe_삭제(
             @Autowired StepRepository stepRepository,
             @Autowired StepAuthHelper stepAuthHelper
         ) throws Exception {


### PR DESCRIPTION
- 연관관계 추가에 따른 테스트 케이스 추가
- 다중 연관관계에 대한 테스트 케이스 추가
- `Recipe`를 삭제할때 해당 `Recipe`가 소속되어있는 `Post`가 삭제되지 않음을 확인하는 검증 코드 추가
- 오탈자 수정