### PR TITLE
QueryDSL의 RepositoryImpl이 DTO에 의존하지 않도록 수정

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/AccountService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/AccountService.java
@@ -6,7 +6,6 @@ import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.CheckDuplicat
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Create;
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Update;
-
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.AccountAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
@@ -15,6 +14,7 @@ import kr.reciptopia.reciptopiaserver.domain.model.UserRole;
 import kr.reciptopia.reciptopiaserver.persistence.repository.AccountRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.implementaion.AccountRepositoryImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -49,7 +49,8 @@ public class AccountService {
     }
 
     public Bulk.Result search(Pageable pageable) {
-        return accountRepositoryImpl.search(pageable);
+        PageImpl<Account> pageImpl = accountRepositoryImpl.search(pageable);
+        return Bulk.Result.of(pageImpl);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/CommentService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/CommentService.java
@@ -13,6 +13,7 @@ import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import kr.reciptopia.reciptopiaserver.persistence.repository.CommentRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.implementaion.CommentRepositoryImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -47,7 +48,8 @@ public class CommentService {
     }
 
     public Bulk.Result search(CommentSearchCondition commentSearchCondition, Pageable pageable) {
-        return commentRepositoryImpl.search(commentSearchCondition, pageable);
+        PageImpl<Comment> pageImpl = commentRepositoryImpl.search(commentSearchCondition, pageable);
+        return Bulk.Result.of(pageImpl);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
@@ -12,6 +12,7 @@ import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import kr.reciptopia.reciptopiaserver.persistence.repository.PostRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.implementaion.PostRepositoryImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -43,7 +44,8 @@ public class PostService {
     }
 
     public Bulk.Result search(PostSearchCondition postSearchCondition, Pageable pageable) {
-        return postRepositoryImpl.search(postSearchCondition, pageable);
+        PageImpl<Post> pageImpl = postRepositoryImpl.search(postSearchCondition, pageable);
+        return Bulk.Result.of(pageImpl);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/AccountRepositoryCustom.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/AccountRepositoryCustom.java
@@ -1,10 +1,10 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.custom;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Bulk;
-
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface AccountRepositoryCustom {
 
-    Bulk.Result search(Pageable pageable);
+    PageImpl<Account> search(Pageable pageable);
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/CommentRepositoryCustom.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/CommentRepositoryCustom.java
@@ -1,10 +1,11 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.custom;
 
 import kr.reciptopia.reciptopiaserver.business.service.spec.searchcondition.CommentSearchCondition;
-import kr.reciptopia.reciptopiaserver.domain.dto.CommentDto.Bulk;
+import kr.reciptopia.reciptopiaserver.domain.model.Comment;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface CommentRepositoryCustom {
 
-	Bulk.Result search(CommentSearchCondition commentSearchCondition, Pageable pageable);
+	PageImpl<Comment> search(CommentSearchCondition commentSearchCondition, Pageable pageable);
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/PostRepositoryCustom.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/PostRepositoryCustom.java
@@ -1,10 +1,11 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.custom;
 
 import kr.reciptopia.reciptopiaserver.business.service.spec.searchcondition.PostSearchCondition;
-import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Bulk;
+import kr.reciptopia.reciptopiaserver.domain.model.Post;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
 
-	Bulk.Result search(PostSearchCondition postSearchCondition, Pageable pageable);
+	PageImpl<Post> search(PostSearchCondition postSearchCondition, Pageable pageable);
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/AccountRepositoryImpl.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/AccountRepositoryImpl.java
@@ -1,8 +1,6 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.implementaion;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Bulk;
 import static kr.reciptopia.reciptopiaserver.domain.model.QAccount.account;
-
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.reciptopia.reciptopiaserver.config.querydsl.PagingUtil;
@@ -19,12 +17,10 @@ public class AccountRepositoryImpl implements AccountRepositoryCustom {
     private final PagingUtil pagingUtil;
 
     @Override
-    public Bulk.Result search(Pageable pageable) {
-
+    public PageImpl<Account> search(Pageable pageable) {
         JPAQuery<Account> query = queryFactory
             .selectFrom(account);
 
-        PageImpl<Account> pageImpl = pagingUtil.getPageImpl(pageable, query, Account.class);
-        return Bulk.Result.of(pageImpl);
+        return pagingUtil.getPageImpl(pageable, query, Account.class);
     }
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/CommentRepositoryImpl.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/CommentRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.reciptopia.reciptopiaserver.business.service.spec.searchcondition.CommentSearchCondition;
 import kr.reciptopia.reciptopiaserver.config.querydsl.PagingUtil;
-import kr.reciptopia.reciptopiaserver.domain.dto.CommentDto.Bulk;
 import kr.reciptopia.reciptopiaserver.domain.model.Comment;
 import kr.reciptopia.reciptopiaserver.persistence.repository.custom.CommentRepositoryCustom;
 import lombok.RequiredArgsConstructor;
@@ -21,14 +20,14 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
 	private final PagingUtil pagingUtil;
 
 	@Override
-	public Bulk.Result search(CommentSearchCondition commentSearchCondition, Pageable pageable) {
+	public PageImpl<Comment> search(CommentSearchCondition commentSearchCondition,
+		Pageable pageable) {
 		JPAQuery<Comment> query = queryFactory
 			.selectFrom(comment)
 			.innerJoin(comment.post, post)
 			.where(eqPostId(commentSearchCondition.postId()));
 
-		PageImpl<Comment> pageImpl = pagingUtil.getPageImpl(pageable, query, Comment.class);
-		return Bulk.Result.of(pageImpl);
+		return pagingUtil.getPageImpl(pageable, query, Comment.class);
 	}
 
 	private BooleanExpression eqPostId(Long postId) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/PostRepositoryImpl.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/PostRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.reciptopia.reciptopiaserver.business.service.spec.searchcondition.PostSearchCondition;
 import kr.reciptopia.reciptopiaserver.config.querydsl.PagingUtil;
-import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Bulk;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import kr.reciptopia.reciptopiaserver.persistence.repository.custom.PostRepositoryCustom;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 	private final PagingUtil pagingUtil;
 
 	@Override
-	public Bulk.Result search(PostSearchCondition postSearchCondition, Pageable pageable) {
+	public PageImpl<Post> search(PostSearchCondition postSearchCondition, Pageable pageable) {
 		JPAQuery<Post> query = queryFactory
 			.selectFrom(post)
 			.innerJoin(post.owner, account)
@@ -30,8 +29,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 				likeTitle(postSearchCondition.titleLike())
 			);
 
-		PageImpl<Post> pageImpl = pagingUtil.getPageImpl(pageable, query, Post.class);
-		return Bulk.Result.of(pageImpl);
+		return pagingUtil.getPageImpl(pageable, query, Post.class);
 	}
 
 	private BooleanExpression eqOwnerId(Long ownerId) {


### PR DESCRIPTION
RepositoryImpl의 `search()` 메소드가 Bulk.Result DTO를 반환하지 않고, PageImpl을 반환하도록 수정

close #135 