### PR TITLE
MainIngredient의 검색 API의 파라미터 추가

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -11,14 +11,14 @@
 
 WARNING: 이 API는 아직 구현 중에 있으며 추후에 변경될 수 있습니다.
 
-NOTE: v0.13.12-alpha
+NOTE: v0.13.13-alpha
 
 ****
-v0.13.12-alpha 변경사항
+v0.13.13-alpha 변경사항
 
 '''
 
-* Recipe 검색 파라미터 추가
+* MainIngredient 검색 파라미터 추가
 
 ****
 
@@ -585,6 +585,8 @@ operation::main-ingredient-list-example[snippets='request-parameters,curl-reques
 <<resources_mainIngredient_list, MainIngredient 목록 조회 API>>에 요청 패러미터를 추가하면 특정 조건을 기준으로 MainIngredient를 검색할 수 있습니다.
 
 operation::main-ingredient-search-example[snippets='request-parameters,curl-request,http-response']
+
+operation::main-ingredient-search-response-example[snippets='response-fields,curl-request,http-response']
 
 [[resources_mainIngredient_create]]
 === MainIngredient 생성

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
@@ -44,8 +44,10 @@ public class MainIngredientService {
         return Result.of(repoHelper.findMainIngredientOrThrow(id));
     }
 
-    public Bulk.Result search(MainIngredientSearchCondition condition, Pageable pageable) {
-        return Bulk.Result.of(mainIngredientRepositoryImpl.search(condition, pageable));
+    public Bulk.ResultGroupBy.PostId search(MainIngredientSearchCondition condition,
+        Pageable pageable) {
+        return Bulk.ResultGroupBy.PostId.of(
+            mainIngredientRepositoryImpl.search(condition, pageable));
     }
 
     @Transactional
@@ -72,8 +74,8 @@ public class MainIngredientService {
     }
 
     @Transactional
-    public Bulk.Result bulkUpdate(Bulk.Update bulkDto, Authentication authentication) {
-        return Bulk.Result.builder()
+    public Bulk.ResultGroupBy.Id bulkUpdate(Bulk.Update bulkDto, Authentication authentication) {
+        return Bulk.ResultGroupBy.Id.builder()
             .mainIngredients(bulkDto.mainIngredients().keySet().stream()
                 .map(id -> update(id, bulkDto.mainIngredients().get(id), authentication))
                 .collect(Collectors.toMap(Result::id, result -> result)))
@@ -81,8 +83,8 @@ public class MainIngredientService {
     }
 
     @Transactional
-    public Bulk.Result bulkCreate(Bulk.Create bulkDto, Authentication authentication) {
-        return Bulk.Result.builder()
+    public Bulk.ResultGroupBy.Id bulkCreate(Bulk.Create bulkDto, Authentication authentication) {
+        return Bulk.ResultGroupBy.Id.builder()
             .mainIngredients(bulkDto.mainIngredients().stream()
                 .map(dto -> create(dto, authentication))
                 .collect(Collectors.toMap(Result::id, result -> result)))

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/MainIngredientSearchCondition.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/MainIngredientSearchCondition.java
@@ -1,11 +1,21 @@
 package kr.reciptopia.reciptopiaserver.business.service.searchcondition;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 
-public record MainIngredientSearchCondition(Long recipeId) {
+public record MainIngredientSearchCondition(Long recipeId, Long postId, List<Long> ids,
+                                            List<Long> recipeIds,
+                                            List<Long> postIds) {
 
     @Builder
-    public MainIngredientSearchCondition(Long recipeId) {
+    public MainIngredientSearchCondition(Long recipeId, Long postId, List<Long> ids,
+        List<Long> recipeIds,
+        List<Long> postIds) {
         this.recipeId = recipeId;
+        this.postId = postId;
+        this.ids = ids == null ? new ArrayList<>() : ids;
+        this.recipeIds = recipeIds == null ? new ArrayList<>() : recipeIds;
+        this.postIds = postIds == null ? new ArrayList<>() : postIds;
     }
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
@@ -5,6 +5,7 @@ import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
 
+import java.util.List;
 import java.util.Set;
 import javax.validation.Valid;
 import kr.reciptopia.reciptopiaserver.business.service.MainIngredientService;
@@ -46,9 +47,17 @@ public class MainIngredientController {
     @GetMapping("/post/recipe/mainIngredients")
     public Bulk.Result search(
         @RequestParam(required = false) Long recipeId,
+        @RequestParam(required = false) Long postId,
+        @RequestParam(required = false) List<Long> ids,
+        @RequestParam(required = false) List<Long> recipeIds,
+        @RequestParam(required = false) List<Long> postIds,
         Pageable pageable) {
         MainIngredientSearchCondition mainIngredientSearchCondition = MainIngredientSearchCondition.builder()
+            .ids(ids)
+            .recipeIds(recipeIds)
+            .postIds(postIds)
             .recipeId(recipeId)
+            .postId(postId)
             .build();
 
         return service.search(mainIngredientSearchCondition, pageable);

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
@@ -45,7 +45,7 @@ public class MainIngredientController {
     }
 
     @GetMapping("/post/recipe/mainIngredients")
-    public Bulk.Result search(
+    public Bulk.ResultGroupBy.PostId search(
         @RequestParam(required = false) Long recipeId,
         @RequestParam(required = false) Long postId,
         @RequestParam(required = false) List<Long> ids,
@@ -78,13 +78,13 @@ public class MainIngredientController {
 
     @PostMapping("/post/recipe/bulk-mainIngredient")
     @ResponseStatus(HttpStatus.CREATED)
-    public Bulk.Result bulkCreate(@Valid @RequestBody Bulk.Create bulkDto,
+    public Bulk.ResultGroupBy.Id bulkCreate(@Valid @RequestBody Bulk.Create bulkDto,
         Authentication authentication) {
         return service.bulkCreate(bulkDto, authentication);
     }
 
     @PatchMapping("/post/recipe/bulk-mainIngredient")
-    public Bulk.Result bulkPatch(@Valid @RequestBody Bulk.Update bulkDto,
+    public Bulk.ResultGroupBy.Id bulkPatch(@Valid @RequestBody Bulk.Update bulkDto,
         Authentication authentication) {
         return service.bulkUpdate(bulkDto, authentication);
     }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/MainIngredientRepositoryCustom.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/custom/MainIngredientRepositoryCustom.java
@@ -1,12 +1,12 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.custom;
 
+import com.querydsl.core.Tuple;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.MainIngredientSearchCondition;
-import kr.reciptopia.reciptopiaserver.domain.model.MainIngredient;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface MainIngredientRepositoryCustom {
 
-    PageImpl<MainIngredient> search(MainIngredientSearchCondition mainIngredientSearchCondition,
+    PageImpl<Tuple> search(MainIngredientSearchCondition mainIngredientSearchCondition,
         Pageable pageable);
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/MainIngredientRepositoryImpl.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/MainIngredientRepositoryImpl.java
@@ -20,7 +20,7 @@ public class MainIngredientRepositoryImpl implements MainIngredientRepositoryCus
 	private final PagingUtil pagingUtil;
 
 	@Override
-	public PageImpl<MainIngredient> search(
+	public PageImpl<Tuple> search(
 		MainIngredientSearchCondition mainIngredientSearchCondition,
 		Pageable pageable) {
 		JPAQuery<MainIngredient> query = queryFactory

--- a/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/MainIngredientRepositoryImpl.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/persistence/repository/implementaion/MainIngredientRepositoryImpl.java
@@ -1,10 +1,13 @@
 package kr.reciptopia.reciptopiaserver.persistence.repository.implementaion;
 
 import static kr.reciptopia.reciptopiaserver.domain.model.QMainIngredient.mainIngredient;
+import static kr.reciptopia.reciptopiaserver.domain.model.QPost.post;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.MainIngredientSearchCondition;
 import kr.reciptopia.reciptopiaserver.config.querydsl.PagingUtil;
 import kr.reciptopia.reciptopiaserver.domain.model.MainIngredient;
@@ -23,15 +26,38 @@ public class MainIngredientRepositoryImpl implements MainIngredientRepositoryCus
 	public PageImpl<Tuple> search(
 		MainIngredientSearchCondition mainIngredientSearchCondition,
 		Pageable pageable) {
-		JPAQuery<MainIngredient> query = queryFactory
-			.selectFrom(mainIngredient)
-			.where(eqRecipeId(mainIngredientSearchCondition.recipeId()));
+		JPAQuery<Tuple> ingredientWithPostId = queryFactory
+			.from(post, mainIngredient)
+			.select(post.id, mainIngredient)
+			.where(
+				post.eq(mainIngredient.recipe.post),
+				eqRecipeId(mainIngredientSearchCondition.recipeId()),
+				eqPostId(mainIngredientSearchCondition.postId()),
+				inIds(mainIngredientSearchCondition.ids()),
+				inRecipeIds(mainIngredientSearchCondition.recipeIds()),
+				inPostIds(mainIngredientSearchCondition.postIds())
+			);
 
-		return pagingUtil.getPageImpl(pageable, query, MainIngredient.class);
+		return pagingUtil.getPageImpl(pageable, ingredientWithPostId, MainIngredient.class);
 	}
 
 	private BooleanExpression eqRecipeId(Long recipeId) {
 		return recipeId == null ? null : mainIngredient.recipe.id.eq(recipeId);
 	}
 
+	private BooleanExpression eqPostId(Long postId) {
+		return postId == null ? null : mainIngredient.recipe.post.id.eq(postId);
+	}
+
+	private BooleanExpression inIds(List<Long> ids) {
+		return ids.isEmpty() ? null : mainIngredient.id.in(ids);
+	}
+
+	private BooleanExpression inRecipeIds(List<Long> recipeIds) {
+		return recipeIds.isEmpty() ? null : mainIngredient.recipe.id.in(recipeIds);
+	}
+
+	private BooleanExpression inPostIds(List<Long> postIds) {
+		return postIds.isEmpty() ? null : mainIngredient.recipe.post.id.in(postIds);
+	}
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -248,8 +249,8 @@ public class MainIngredientIntegrationTest {
             // Then
             actions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.mainIngredients").value(aMapWithSize(2)))
-                .andExpect(jsonPath("$.mainIngredients.[*].id").value(containsInAnyOrder(
+                .andExpect(jsonPath("$.mainIngredients.[*].[*]").value(hasSize(2)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(containsInAnyOrder(
                     mainIngredientAId.intValue(),
                     mainIngredientBId.intValue()
                 )));
@@ -287,8 +288,8 @@ public class MainIngredientIntegrationTest {
             // Then
             actions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.mainIngredients").value(aMapWithSize(2)))
-                .andExpect(jsonPath("$.mainIngredients.[*].id").value(contains(
+                .andExpect(jsonPath("$.mainIngredients.[*].[*]").value(hasSize(2)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(contains(
                     mainIngredientBId.intValue(),
                     mainIngredientAId.intValue()
                 )));
@@ -327,8 +328,8 @@ public class MainIngredientIntegrationTest {
             // Then
             actions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.mainIngredients").value(aMapWithSize(2)))
-                .andExpect(jsonPath("$.mainIngredients.[*].id").value(containsInAnyOrder(
+                .andExpect(jsonPath("$.mainIngredients.[*].[*]").value(hasSize(2)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(containsInAnyOrder(
                     mainIngredientBId.intValue(),
                     mainIngredientCId.intValue()
                 )));

--- a/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
@@ -74,6 +74,12 @@ public class MainIngredientIntegrationTest {
 
     private static final ParameterDescriptor DOC_PARAMETER_RECIPE_ID =
         parameterWithName("recipeId").description("레시피 ID").optional();
+    private static final ParameterDescriptor DOC_PARAMETER_RECIPE_IDS =
+        parameterWithName("recipeIds").description("레시피 ID 배열").optional();
+    private static final ParameterDescriptor DOC_PARAMETER_POST_ID =
+        parameterWithName("postId").description("게시물 ID").optional();
+    private static final ParameterDescriptor DOC_PARAMETER_POST_IDS =
+        parameterWithName("postIds").description("게시물 ID 배열").optional();
 
     private static final FieldDescriptor DOC_FIELD_POST_BULK_MAIN_INGREDIENTS =
         fieldWithPath("mainIngredients").type("MainIngredient[]").description("주 재료 생성 필요필드 배열");
@@ -84,6 +90,9 @@ public class MainIngredientIntegrationTest {
     private static final FieldDescriptor DOC_FIELD_PATCH_BULK_MAIN_INGREDIENTS =
         subsectionWithPath("mainIngredients").type("Map<id, mainIngredient>")
             .description("주 재료 수정 필요필드 배열");
+    private static final FieldDescriptor DOC_FIELD_BULK_MAIN_INGREDIENTS_GRUOP_BY_POST =
+        subsectionWithPath("mainIngredients").type("Map<postId, List<mainIngredient>>")
+            .description("주 재료가 속한 Post의 Id를 Key 로 하고 주 재료 List를 Value 갖는 Map");
 
     @Autowired
     PasswordEncoder passwordEncoder;
@@ -337,7 +346,13 @@ public class MainIngredientIntegrationTest {
             // Document
             actions.andDo(document("main-ingredient-search-example",
                 requestParameters(
-                    DOC_PARAMETER_RECIPE_ID
+                    DOC_PARAMETER_RECIPE_ID,
+                    DOC_PARAMETER_RECIPE_IDS,
+                    DOC_PARAMETER_POST_ID,
+                    DOC_PARAMETER_POST_IDS
+                ))).andDo(document("main-ingredient-search-response-example",
+                responseFields(
+                    DOC_FIELD_BULK_MAIN_INGREDIENTS_GRUOP_BY_POST
                 )));
         }
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
@@ -341,6 +341,166 @@ public class MainIngredientIntegrationTest {
                 )));
         }
 
+        @Test
+        void searchMainIngredientsByPostId() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                MainIngredient mainIngredientA = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientB = entityHelper.generateMainIngredient(it -> it
+                    .withRecipe(recipe));
+                MainIngredient mainIngredientC = entityHelper.generateMainIngredient(it -> it
+                    .withRecipe(recipe));
+                MainIngredient mainIngredientD = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientE = entityHelper.generateMainIngredient();
+
+                return new Struct()
+                    .withValue("postId", recipe.getPost().getId())
+                    .withValue("mainIngredientBId", mainIngredientB.getId())
+                    .withValue("mainIngredientCId", mainIngredientC.getId());
+            });
+            Long postId = given.valueOf("postId");
+            Long mainIngredientBId = given.valueOf("mainIngredientBId");
+            Long mainIngredientCId = given.valueOf("mainIngredientCId");
+
+            // When
+            ResultActions actions = mockMvc.perform(get("/post/recipe/mainIngredients")
+                .param("postId", postId.toString()));
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mainIngredients.[*].[*]").value(hasSize(2)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(containsInAnyOrder(
+                    mainIngredientBId.intValue(),
+                    mainIngredientCId.intValue()
+                )));
+        }
+
+        @Test
+        void searchMainIngredientsByIds() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+
+                MainIngredient mainIngredientA = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientB = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientC = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientD = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientE = entityHelper.generateMainIngredient();
+
+                return new Struct()
+                    .withValue("mainIngredientBId", mainIngredientB.getId())
+                    .withValue("mainIngredientCId", mainIngredientC.getId())
+                    .withValue("mainIngredientEId", mainIngredientE.getId());
+            });
+            Long mainIngredientBId = given.valueOf("mainIngredientBId");
+            Long mainIngredientCId = given.valueOf("mainIngredientCId");
+            Long mainIngredientEId = given.valueOf("mainIngredientEId");
+
+            // When
+            String idsParam =
+                mainIngredientBId + ", " + mainIngredientCId + ", " + mainIngredientEId;
+            ResultActions actions = mockMvc.perform(get("/post/recipe/mainIngredients")
+                .param("ids", idsParam));
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mainIngredients.[*].[*]").value(hasSize(3)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(
+                    containsInAnyOrder(
+                        mainIngredientCId.intValue(),
+                        mainIngredientBId.intValue(),
+                        mainIngredientEId.intValue()
+                    )));
+        }
+
+        @Test
+        void searchMainIngredientsByRecipeIds() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+
+                MainIngredient mainIngredientA = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientB = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientC = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientD = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientE = entityHelper.generateMainIngredient();
+
+                return new Struct()
+                    .withValue("mainIngredientBId", mainIngredientB.getId())
+                    .withValue("mainIngredientCId", mainIngredientC.getId())
+                    .withValue("mainIngredientEId", mainIngredientE.getId())
+                    .withValue("recipeBId", mainIngredientB.getRecipe().getId())
+                    .withValue("recipeCId", mainIngredientC.getRecipe().getId())
+                    .withValue("recipeEId", mainIngredientE.getRecipe().getId());
+            });
+            Long mainIngredientBId = given.valueOf("mainIngredientBId");
+            Long mainIngredientCId = given.valueOf("mainIngredientCId");
+            Long mainIngredientEId = given.valueOf("mainIngredientEId");
+            Long recipeBId = given.valueOf("recipeBId");
+            Long recipeCId = given.valueOf("recipeCId");
+            Long recipeEId = given.valueOf("recipeEId");
+
+            // When
+            String recipeIdsParam = recipeBId + ", " + recipeCId + ", " + recipeEId;
+            ResultActions actions = mockMvc.perform(get("/post/recipe/mainIngredients")
+                .param("recipeIds", recipeIdsParam));
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mainIngredients").value(aMapWithSize(3)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(
+                    containsInAnyOrder(
+                        mainIngredientCId.intValue(),
+                        mainIngredientBId.intValue(),
+                        mainIngredientEId.intValue()
+                    )));
+        }
+
+        @Test
+        void searchMainIngredientsByPostIds() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+
+                MainIngredient mainIngredientA = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientB = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientC = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientD = entityHelper.generateMainIngredient();
+                MainIngredient mainIngredientE = entityHelper.generateMainIngredient();
+
+                return new Struct()
+                    .withValue("mainIngredientBId", mainIngredientB.getId())
+                    .withValue("mainIngredientCId", mainIngredientC.getId())
+                    .withValue("mainIngredientEId", mainIngredientE.getId())
+                    .withValue("postBId", mainIngredientB.getRecipe().getPost().getId())
+                    .withValue("postCId", mainIngredientC.getRecipe().getPost().getId())
+                    .withValue("postEId", mainIngredientE.getRecipe().getPost().getId());
+            });
+            Long mainIngredientBId = given.valueOf("mainIngredientBId");
+            Long mainIngredientCId = given.valueOf("mainIngredientCId");
+            Long mainIngredientEId = given.valueOf("mainIngredientEId");
+            Long postBId = given.valueOf("postBId");
+            Long postCId = given.valueOf("postCId");
+            Long postEId = given.valueOf("postEId");
+
+            // When
+            String postIdsParam = postBId + ", " + postCId + ", " + postEId;
+            ResultActions actions = mockMvc.perform(get("/post/recipe/mainIngredients")
+                .param("postIds", postIdsParam));
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mainIngredients").value(aMapWithSize(3)))
+                .andExpect(jsonPath("$.mainIngredients.[*].[*].id").value(
+                    containsInAnyOrder(
+                        mainIngredientCId.intValue(),
+                        mainIngredientBId.intValue(),
+                        mainIngredientEId.intValue()
+                    )));
+        }
     }
 
     @Nested

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
@@ -91,8 +91,8 @@ public class MainIngredientHelper {
                 .build();
         }
 
-        static MainIngredientDto.Bulk.Result tripleMainIngredientsBulkResultDto() {
-            return MainIngredientDto.Bulk.Result.builder()
+        static MainIngredientDto.Bulk.ResultGroupBy.Id tripleMainIngredientsBulkResultDto() {
+            return MainIngredientDto.Bulk.ResultGroupBy.Id.builder()
                 .mainIngredient(ARBITRARY_BULK_ID_0,
                     MainIngredientHelper.aMainIngredientResultDto())
                 .mainIngredient(ARBITRARY_BULK_ID_1,


### PR DESCRIPTION
- `recipeId` ,  `recipeIds` ,  `postId` ,  `postIds` 를 이용한 검색 추가
- `MainIngredient` 의 검색 응답값 형태 변경
  - `PostId` 를 Key로 , `List형태의 MainIngredient` 를 Value로 갖는 `Map` 형식으로 변경