### PR TITLE
Recipe Post API 추가

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -11,14 +11,14 @@
 
 WARNING: 이 API는 아직 구현 중에 있으며 추후에 변경될 수 있습니다.
 
-NOTE: v0.13.13-alpha
+NOTE: v0.14.0-alpha
 
 ****
-v0.13.13-alpha 변경사항
+v0.14.0-alpha 변경사항
 
 '''
 
-* MainIngredient 검색 파라미터 추가
+* RecipePost 리소스 추가
 
 ****
 
@@ -369,6 +369,17 @@ operation::post-update-example[snippets='request-fields,curl-request,http-respon
 요청의 `Authorization` 헤더로 요청을 보낸 글쓴이 `Account` 의 엑세스 토큰이 제공되어야 합니다.
 
 operation::post-delete-example[snippets='curl-request,http-response']
+
+[[resources_recipe_post]]
+== RecipePost 리소스
+
+[[resources_recipe_post_create]]
+=== RecipePost 생성
+
+`POST /recipePosts` 요청으로 RecipePost를 생성합니다.
+성공 시 생성한 RecipePost를 응답 Body로 전달합니다.
+
+operation::recipe-post-create-example[snippets='request-fields,curl-request,response-fields,http-response']
 
 [[resources_comment]]
 == Comment 리소스

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
@@ -1,7 +1,7 @@
 package kr.reciptopia.reciptopiaserver.business.service;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
 
@@ -31,7 +31,7 @@ public class MainIngredientService {
     private final IngredientAuthorizer ingredientAuthorizer;
 
     @Transactional
-    public Result create(Create dto, Authentication authentication) {
+    public Result create(Single dto, Authentication authentication) {
         Recipe recipe = repoHelper.findRecipeOrThrow(dto.recipeId());
         ingredientAuthorizer.requireRecipeOwner(authentication, recipe);
 
@@ -83,7 +83,8 @@ public class MainIngredientService {
     }
 
     @Transactional
-    public Bulk.ResultGroupBy.Id bulkCreate(Bulk.Create bulkDto, Authentication authentication) {
+    public Bulk.ResultGroupBy.Id bulkCreate(Bulk.Create.Single bulkDto,
+        Authentication authentication) {
         return Bulk.ResultGroupBy.Id.builder()
             .mainIngredients(bulkDto.mainIngredients().stream()
                 .map(dto -> create(dto, authentication))

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/MainIngredientService.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.IngredientAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.MainIngredientSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipeDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto;
 import kr.reciptopia.reciptopiaserver.domain.model.MainIngredient;
 import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
 import kr.reciptopia.reciptopiaserver.persistence.repository.MainIngredientRepository;
@@ -90,6 +92,15 @@ public class MainIngredientService {
                 .map(dto -> create(dto, authentication))
                 .collect(Collectors.toMap(Result::id, result -> result)))
             .build();
+    }
+
+    @Transactional
+    public Bulk.ResultGroupBy.Id bulkCreate(RecipePostDto.Create dto, Authentication authentication,
+        RecipeDto.Result recipeResult) {
+        Bulk.Create.WithRecipe mainIngredientBulkDto = dto.mainIngredients();
+        Bulk.Create.Single mainIngredientBulkSingle = mainIngredientBulkDto.asSingleDto(
+            it -> it.withRecipeId(recipeResult.id()));
+        return bulkCreate(mainIngredientBulkSingle, authentication);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/RecipePostService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/RecipePostService.java
@@ -1,0 +1,51 @@
+package kr.reciptopia.reciptopiaserver.business.service;
+
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Result;
+
+import kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.PostDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipeDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.StepDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecipePostService {
+
+    private final PostService postService;
+    private final RecipeService recipeService;
+    private final MainIngredientService mainIngredientService;
+    private final SubIngredientService subIngredientService;
+    private final StepService stepService;
+
+    @Transactional
+    public Result create(Create dto, Authentication authentication) {
+        PostDto.Result postResult = postService.create(dto.post(), authentication);
+
+        RecipeDto.Result recipeResult = recipeService.create(authentication, postResult);
+
+        MainIngredientDto.Bulk.ResultGroupBy.Id mainIngredientBulkResult =
+            mainIngredientService.bulkCreate(dto, authentication, recipeResult);
+
+        SubIngredientDto.Bulk.Result subIngredientBulkResult =
+            subIngredientService.bulkCreate(dto, authentication, recipeResult);
+
+        StepDto.Bulk.Result stepBulkResult =
+            stepService.bulkCreate(dto, authentication, recipeResult);
+
+        return Result.builder()
+            .post(postResult)
+            .recipe(recipeResult)
+            .bulkMainIngredient(mainIngredientBulkResult)
+            .bulkSubIngredient(subIngredientBulkResult)
+            .bulkStep(stepBulkResult)
+            .build();
+    }
+
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/RecipeService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/RecipeService.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.RecipeAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.RecipeSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.PostDto;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
 import kr.reciptopia.reciptopiaserver.persistence.repository.RecipeRepository;
@@ -40,6 +41,14 @@ public class RecipeService {
         Recipe recipe = dto.asEntity().withPost(post);
 
         return Result.of(recipeRepository.save(recipe));
+    }
+
+    @Transactional
+    public Result create(Authentication authentication, PostDto.Result postResult) {
+        Create recipeDto = Create.builder()
+            .postId(postResult.id())
+            .build();
+        return create(recipeDto, authentication);
     }
 
     public Result read(Long id) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/StepService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/StepService.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.StepAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.StepSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipeDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto;
 import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
 import kr.reciptopia.reciptopiaserver.domain.model.Step;
 import kr.reciptopia.reciptopiaserver.persistence.repository.StepRepository;
@@ -87,6 +89,16 @@ public class StepService {
                 .map(dto -> create(dto, authentication))
                 .collect(Collectors.toMap(Result::id, result -> result)))
             .build();
+    }
+
+    @Transactional
+    public Bulk.Result bulkCreate(RecipePostDto.Create dto, Authentication authentication,
+        RecipeDto.Result recipeResult) {
+        Bulk.Create.WithRecipe stepBulkDto = dto.steps();
+        Bulk.Create.Single stepBulkSingle = stepBulkDto.asSingleDto(
+            it -> it.withRecipeId(recipeResult.id()));
+        return bulkCreate(
+            stepBulkSingle, authentication);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/StepService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/StepService.java
@@ -1,7 +1,7 @@
 package kr.reciptopia.reciptopiaserver.business.service;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Update;
 
@@ -31,7 +31,7 @@ public class StepService {
     private final StepAuthorizer stepAuthorizer;
 
     @Transactional
-    public Result create(Create dto, Authentication authentication) {
+    public Result create(Single dto, Authentication authentication) {
         Recipe recipe = repoHelper.findRecipeOrThrow(dto.recipeId());
         stepAuthorizer.requireRecipeOwner(authentication, recipe);
 
@@ -81,7 +81,7 @@ public class StepService {
     }
 
     @Transactional
-    public Bulk.Result bulkCreate(Bulk.Create bulkDto, Authentication authentication) {
+    public Bulk.Result bulkCreate(Bulk.Create.Single bulkDto, Authentication authentication) {
         return Bulk.Result.builder()
             .steps(bulkDto.steps().stream()
                 .map(dto -> create(dto, authentication))

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
@@ -1,9 +1,10 @@
 package kr.reciptopia.reciptopiaserver.business.service;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Update;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.IngredientAuthorizer;
@@ -30,7 +31,7 @@ public class SubIngredientService {
     private final IngredientAuthorizer ingredientAuthorizer;
 
     @Transactional
-    public Result create(Create dto, Authentication authentication) {
+    public Result create(Single dto, Authentication authentication) {
         Recipe recipe = repoHelper.findRecipeOrThrow(dto.recipeId());
         ingredientAuthorizer.requireRecipeOwner(authentication, recipe);
 
@@ -71,7 +72,7 @@ public class SubIngredientService {
     }
 
     @Transactional
-    public Bulk.Result bulkCreate(Bulk.Create bulkDto, Authentication authentication) {
+    public Bulk.Result bulkCreate(Bulk.Create.Single bulkDto, Authentication authentication) {
         return Bulk.Result.builder()
             .subIngredients(bulkDto.subIngredients().stream()
                 .map(dto -> create(dto, authentication))

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.IngredientAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.SubIngredientSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipeDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto;
 import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
 import kr.reciptopia.reciptopiaserver.domain.model.SubIngredient;
 import kr.reciptopia.reciptopiaserver.persistence.repository.SubIngredientRepository;
@@ -78,6 +80,16 @@ public class SubIngredientService {
                 .map(dto -> create(dto, authentication))
                 .collect(Collectors.toMap(Result::id, result -> result)))
             .build();
+    }
+
+    @Transactional
+    public Bulk.Result bulkCreate(RecipePostDto.Create dto, Authentication authentication,
+        RecipeDto.Result recipeResult) {
+        Bulk.Create.WithRecipe subIngredientBulkDto = dto.subIngredients();
+        Bulk.Create.Single subIngredientBulkSingle = subIngredientBulkDto.asSingleDto(
+            it -> it.withRecipeId(recipeResult.id()));
+        return bulkCreate(
+            subIngredientBulkSingle, authentication);
     }
 
     @Transactional

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/MainIngredientController.java
@@ -1,7 +1,7 @@
 package kr.reciptopia.reciptopiaserver.controller;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
 
@@ -34,7 +34,7 @@ public class MainIngredientController {
 
     @PostMapping("/post/recipe/mainIngredients")
     @ResponseStatus(HttpStatus.CREATED)
-    public Result post(@Valid @RequestBody Create dto,
+    public Result post(@Valid @RequestBody Single dto,
         Authentication authentication) {
         return service.create(dto, authentication);
     }
@@ -78,7 +78,7 @@ public class MainIngredientController {
 
     @PostMapping("/post/recipe/bulk-mainIngredient")
     @ResponseStatus(HttpStatus.CREATED)
-    public Bulk.ResultGroupBy.Id bulkCreate(@Valid @RequestBody Bulk.Create bulkDto,
+    public Bulk.ResultGroupBy.Id bulkCreate(@Valid @RequestBody Bulk.Create.Single bulkDto,
         Authentication authentication) {
         return service.bulkCreate(bulkDto, authentication);
     }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/RecipePostController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/RecipePostController.java
@@ -1,0 +1,29 @@
+package kr.reciptopia.reciptopiaserver.controller;
+
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Result;
+
+import javax.validation.Valid;
+import kr.reciptopia.reciptopiaserver.business.service.RecipePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class RecipePostController {
+
+    private final RecipePostService service;
+
+    @PostMapping("/recipePosts")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Result post(@Valid @RequestBody Create dto, Authentication authentication) {
+        return service.create(dto, authentication);
+    }
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/StepController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/StepController.java
@@ -1,7 +1,6 @@
 package kr.reciptopia.reciptopiaserver.controller;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Update;
 
@@ -9,6 +8,7 @@ import java.util.Set;
 import javax.validation.Valid;
 import kr.reciptopia.reciptopiaserver.business.service.StepService;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.StepSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.StepDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -33,14 +33,14 @@ public class StepController {
 
     @PostMapping("/post/recipe/steps")
     @ResponseStatus(HttpStatus.CREATED)
-    public Result post(@Valid @RequestBody Create dto,
+    public Result post(@Valid @RequestBody StepDto.Create.Single dto,
         Authentication authentication) {
         return service.create(dto, authentication);
     }
 
     @PostMapping("/post/recipe/bulk-step")
     @ResponseStatus(HttpStatus.CREATED)
-    public Bulk.Result bulkCreate(@Valid @RequestBody Bulk.Create bulkDto,
+    public Bulk.Result bulkCreate(@Valid @RequestBody StepDto.Bulk.Create.Single bulkDto,
         Authentication authentication) {
         return service.bulkCreate(bulkDto, authentication);
     }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/SubIngredientController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/SubIngredientController.java
@@ -1,12 +1,13 @@
 package kr.reciptopia.reciptopiaserver.controller;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Update;
+
 import java.util.Set;
 import javax.validation.Valid;
 import kr.reciptopia.reciptopiaserver.business.service.SubIngredientService;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.SubIngredientSearchCondition;
+import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto;
 import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Bulk;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +33,7 @@ public class SubIngredientController {
 
     @PostMapping("/post/recipe/subIngredients")
     @ResponseStatus(HttpStatus.CREATED)
-    public Result post(@Valid @RequestBody Create dto,
+    public Result post(@Valid @RequestBody SubIngredientDto.Create.Single dto,
         Authentication authentication) {
         return service.create(dto, authentication);
     }
@@ -68,7 +69,7 @@ public class SubIngredientController {
 
     @PostMapping("/post/recipe/bulk-subIngredient")
     @ResponseStatus(HttpStatus.CREATED)
-    public Bulk.Result bulkCreate(@Valid @RequestBody Bulk.Create bulkDto,
+    public Bulk.Result bulkCreate(@Valid @RequestBody SubIngredientDto.Bulk.Create.Single bulkDto,
         Authentication authentication) {
         return service.bulkCreate(bulkDto, authentication);
     }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/MainIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/MainIngredientDto.java
@@ -24,6 +24,30 @@ public interface MainIngredientDto {
 
         interface Create {
 
+            record WithRecipe(
+                List<MainIngredientDto.Create.WithRecipe> mainIngredients
+            ) {
+
+                @Builder
+                public WithRecipe(
+                    @NotEmpty
+                    @Singular
+                        List<MainIngredientDto.Create.WithRecipe> mainIngredients
+                ) {
+                    this.mainIngredients = mainIngredients;
+                }
+
+                public Single asSingleDto(
+                    Function<? super MainIngredientDto.Create.Single, ? extends MainIngredientDto.Create.Single> initialize) {
+                    List<MainIngredientDto.Create.Single> singleDtos = this.mainIngredients.stream()
+                        .map(m -> m.asSingleDto(initialize))
+                        .collect(Collectors.toList());
+                    return Single.builder()
+                        .mainIngredients(singleDtos)
+                        .build();
+                }
+            }
+
             @With
             record Single(
                 List<MainIngredientDto.Create.Single> mainIngredients
@@ -130,6 +154,31 @@ public interface MainIngredientDto {
     }
 
     interface Create {
+
+        record WithRecipe(
+            String name, String detail
+        ) {
+
+            @Builder
+            public WithRecipe(
+
+                @NotEmpty
+                    String name,
+
+                @NotEmpty
+                    String detail) {
+                this.name = name;
+                this.detail = detail;
+            }
+
+            public Single asSingleDto(
+                Function<? super Single, ? extends Single> initialize) {
+                return initialize.apply(Single.builder()
+                    .name(name)
+                    .detail(detail)
+                    .build());
+            }
+        }
 
         @With
         record Single(

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/MainIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/MainIngredientDto.java
@@ -22,24 +22,27 @@ public interface MainIngredientDto {
 
     interface Bulk {
 
-        @With
-        record Create(
-            List<MainIngredientDto.Create> mainIngredients
-        ) {
+        interface Create {
 
-            @Builder
-            public Create(
-                @NotEmpty
-                @Singular
-                    List<MainIngredientDto.Create> mainIngredients
+            @With
+            record Single(
+                List<MainIngredientDto.Create.Single> mainIngredients
             ) {
-                this.mainIngredients = mainIngredients;
-            }
 
-            public Set<MainIngredient> asEntity() {
-                return this.mainIngredients.stream()
-                    .map(MainIngredientDto.Create::asEntity)
-                    .collect(Collectors.toSet());
+                @Builder
+                public Single(
+                    @NotEmpty
+                    @Singular
+                        List<MainIngredientDto.Create.Single> mainIngredients
+                ) {
+                    this.mainIngredients = mainIngredients;
+                }
+
+                public Set<MainIngredient> asEntity() {
+                    return this.mainIngredients.stream()
+                        .map(MainIngredientDto.Create.Single::asEntity)
+                        .collect(Collectors.toSet());
+                }
             }
         }
 
@@ -126,48 +129,52 @@ public interface MainIngredientDto {
         }
     }
 
-    @With
-    record Create(
-        Long recipeId, String name, String detail
-    ) {
+    interface Create {
 
-        @Builder
-        public Create(
-            @NotNull
-                Long recipeId,
+        @With
+        record Single(
+            Long recipeId, String name, String detail
+        ) {
 
-            @NotEmpty
-                String name,
+            @Builder
+            public Single(
+                @NotNull
+                    Long recipeId,
 
-            @NotEmpty
-                String detail) {
-            this.recipeId = recipeId;
-            this.name = name;
-            this.detail = detail;
-        }
+                @NotEmpty
+                    String name,
 
-        public MainIngredient asEntity(
-            Function<? super MainIngredient, ? extends MainIngredient> initialize) {
-            return initialize.apply(MainIngredient.builder()
-                .name(name)
-                .detail(detail)
-                .build());
-        }
+                @NotEmpty
+                    String detail) {
+                this.recipeId = recipeId;
+                this.name = name;
+                this.detail = detail;
+            }
 
-        public MainIngredient asEntity() {
-            return asEntity(noInit());
-        }
+            public MainIngredient asEntity(
+                Function<? super MainIngredient, ? extends MainIngredient> initialize) {
+                return initialize.apply(MainIngredient.builder()
+                    .name(name)
+                    .detail(detail)
+                    .build());
+            }
 
-        private <T> Function<? super T, ? extends T> noInit() {
-            return (arg) -> arg;
-        }
+            public MainIngredient asEntity() {
+                return asEntity(noInit());
+            }
 
-        public Create withRecipeId(Long recipeId) {
-            return this.recipeId != null && this.recipeId.equals(recipeId) ? this : Create.builder()
-                .recipeId(recipeId)
-                .name(name)
-                .detail(detail)
-                .build();
+            private <T> Function<? super T, ? extends T> noInit() {
+                return (arg) -> arg;
+            }
+
+            public Single withRecipeId(Long recipeId) {
+                return this.recipeId != null && this.recipeId.equals(recipeId) ? this
+                    : Single.builder()
+                        .recipeId(recipeId)
+                        .name(name)
+                        .detail(detail)
+                        .build();
+            }
         }
     }
 

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/PostDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/PostDto.java
@@ -97,12 +97,30 @@ public interface PostDto {
             this.pictureUrls = pictureUrls;
         }
 
+        public Post asEntity(
+            Function<? super Post, ? extends Post> initialize) {
+            return initialize.apply(Post.builder()
+                .title(title)
+                .content(content)
+                .pictureUrls(pictureUrls)
+                .build());
+        }
+
         public Post asEntity() {
-            return Post.builder()
+            return asEntity(noInit());
+        }
+
+        public Create withOwnerId(Long ownerId) {
+            return this.ownerId != null && this.ownerId.equals(ownerId) ? this : Create.builder()
+                .ownerId(ownerId)
                 .title(title)
                 .content(content)
                 .pictureUrls(pictureUrls)
                 .build();
+        }
+
+        private <T> Function<? super T, ? extends T> noInit() {
+            return (arg) -> arg;
         }
     }
 

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
@@ -1,0 +1,41 @@
+package kr.reciptopia.reciptopiaserver.domain.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.With;
+
+public interface RecipePostDto {
+
+    @With
+    record Create(
+        PostDto.Create post, MainIngredientDto.Bulk.Create.WithRecipe mainIngredients,
+        SubIngredientDto.Bulk.Create.WithRecipe subIngredients, StepDto.Bulk.Create.WithRecipe steps
+    ) {
+
+        @Builder
+        public Create(
+            @NotNull
+                PostDto.Create post,
+
+            MainIngredientDto.Bulk.Create.WithRecipe mainIngredients,
+            SubIngredientDto.Bulk.Create.WithRecipe subIngredients,
+            StepDto.Bulk.Create.WithRecipe steps) {
+            this.post = post;
+            this.mainIngredients = mainIngredients;
+            this.subIngredients = subIngredients;
+            this.steps = steps;
+        }
+    }
+
+    @With
+    record Result(
+        PostDto.Result post, RecipeDto.Result recipe,
+        MainIngredientDto.Bulk.ResultGroupBy.Id bulkMainIngredient,
+        SubIngredientDto.Bulk.Result bulkSubIngredient, StepDto.Bulk.Result bulkStep
+    ) {
+
+        @Builder
+        public Result {
+        }
+    }
+}

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/StepDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/StepDto.java
@@ -21,6 +21,30 @@ public interface StepDto {
 
         interface Create {
 
+            record WithRecipe(
+                List<StepDto.Create.WithRecipe> steps
+            ) {
+
+                @Builder
+                public WithRecipe(
+                    @NotEmpty
+                    @Singular
+                        List<StepDto.Create.WithRecipe> steps
+                ) {
+                    this.steps = steps;
+                }
+
+                public StepDto.Bulk.Create.Single asSingleDto(
+                    Function<? super StepDto.Create.Single, ? extends StepDto.Create.Single> initialize) {
+                    List<StepDto.Create.Single> singleDtos = this.steps.stream()
+                        .map(m -> m.asSingleDto(initialize))
+                        .collect(Collectors.toList());
+                    return StepDto.Bulk.Create.Single.builder()
+                        .steps(singleDtos)
+                        .build();
+                }
+            }
+
             @With
             record Single(
                 List<StepDto.Create.Single> steps
@@ -93,6 +117,30 @@ public interface StepDto {
     }
 
     interface Create {
+
+        record WithRecipe(
+            String description, String pictureUrl
+        ) {
+
+            @Builder
+            public WithRecipe(
+
+                @NotEmpty
+                    String description,
+
+                String pictureUrl) {
+                this.description = description;
+                this.pictureUrl = pictureUrl;
+            }
+
+            public StepDto.Create.Single asSingleDto(
+                Function<? super StepDto.Create.Single, ? extends StepDto.Create.Single> initialize) {
+                return initialize.apply(StepDto.Create.Single.builder()
+                    .description(description)
+                    .pictureUrl(pictureUrl)
+                    .build());
+            }
+        }
 
         @With
         record Single(

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/StepDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/StepDto.java
@@ -19,24 +19,27 @@ public interface StepDto {
 
     interface Bulk {
 
-        @With
-        record Create(
-            List<StepDto.Create> steps
-        ) {
+        interface Create {
 
-            @Builder
-            public Create(
-                @NotEmpty
-                @Singular
-                    List<StepDto.Create> steps
+            @With
+            record Single(
+                List<StepDto.Create.Single> steps
             ) {
-                this.steps = steps;
-            }
 
-            public List<Step> asEntity() {
-                return this.steps.stream()
-                    .map(StepDto.Create::asEntity)
-                    .collect(Collectors.toList());
+                @Builder
+                public Single(
+                    @NotEmpty
+                    @Singular
+                        List<StepDto.Create.Single> steps
+                ) {
+                    this.steps = steps;
+                }
+
+                public List<Step> asEntity() {
+                    return this.steps.stream()
+                        .map(StepDto.Create.Single::asEntity)
+                        .collect(Collectors.toList());
+                }
             }
         }
 
@@ -89,47 +92,51 @@ public interface StepDto {
         }
     }
 
-    @With
-    record Create(
-        Long recipeId, String description, String pictureUrl
-    ) {
+    interface Create {
 
-        @Builder
-        public Create(
-            @NotNull
-                Long recipeId,
+        @With
+        record Single(
+            Long recipeId, String description, String pictureUrl
+        ) {
 
-            @NotEmpty
-                String description,
+            @Builder
+            public Single(
+                @NotNull
+                    Long recipeId,
 
-            String pictureUrl) {
-            this.recipeId = recipeId;
-            this.description = description;
-            this.pictureUrl = pictureUrl;
-        }
+                @NotEmpty
+                    String description,
 
-        public Step asEntity(
-            Function<? super Step, ? extends Step> initialize) {
-            return initialize.apply(Step.builder()
-                .description(description)
-                .pictureUrl(pictureUrl)
-                .build());
-        }
+                String pictureUrl) {
+                this.recipeId = recipeId;
+                this.description = description;
+                this.pictureUrl = pictureUrl;
+            }
 
-        public Step asEntity() {
-            return asEntity(noInit());
-        }
+            public Step asEntity(
+                Function<? super Step, ? extends Step> initialize) {
+                return initialize.apply(Step.builder()
+                    .description(description)
+                    .pictureUrl(pictureUrl)
+                    .build());
+            }
 
-        public Create withRecipeId(Long recipeId) {
-            return this.recipeId != null && this.recipeId.equals(recipeId) ? this : Create.builder()
-                .recipeId(recipeId)
-                .description(description)
-                .pictureUrl(pictureUrl)
-                .build();
-        }
+            public Step asEntity() {
+                return asEntity(noInit());
+            }
 
-        private <T> Function<? super T, ? extends T> noInit() {
-            return (arg) -> arg;
+            public Single withRecipeId(Long recipeId) {
+                return this.recipeId != null && this.recipeId.equals(recipeId) ? this
+                    : Single.builder()
+                        .recipeId(recipeId)
+                        .description(description)
+                        .pictureUrl(pictureUrl)
+                        .build();
+            }
+
+            private <T> Function<? super T, ? extends T> noInit() {
+                return (arg) -> arg;
+            }
         }
     }
 

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -21,6 +21,30 @@ public interface SubIngredientDto {
 
         interface Create {
 
+            record WithRecipe(
+                List<SubIngredientDto.Create.WithRecipe> subIngredients
+            ) {
+
+                @Builder
+                public WithRecipe(
+                    @NotEmpty
+                    @Singular
+                        List<SubIngredientDto.Create.WithRecipe> subIngredients
+                ) {
+                    this.subIngredients = subIngredients;
+                }
+
+                public SubIngredientDto.Bulk.Create.Single asSingleDto(
+                    Function<? super SubIngredientDto.Create.Single, ? extends SubIngredientDto.Create.Single> initialize) {
+                    List<SubIngredientDto.Create.Single> singleDtos = this.subIngredients.stream()
+                        .map(m -> m.asSingleDto(initialize))
+                        .collect(Collectors.toList());
+                    return SubIngredientDto.Bulk.Create.Single.builder()
+                        .subIngredients(singleDtos)
+                        .build();
+                }
+            }
+
             @With
             record Single(
                 List<SubIngredientDto.Create.Single> subIngredients
@@ -88,6 +112,31 @@ public interface SubIngredientDto {
     }
 
     interface Create {
+
+        record WithRecipe(
+            String name, String detail
+        ) {
+
+            @Builder
+            public WithRecipe(
+
+                @NotEmpty
+                    String name,
+
+                @NotEmpty
+                    String detail) {
+                this.name = name;
+                this.detail = detail;
+            }
+
+            public SubIngredientDto.Create.Single asSingleDto(
+                Function<? super SubIngredientDto.Create.Single, ? extends SubIngredientDto.Create.Single> initialize) {
+                return initialize.apply(SubIngredientDto.Create.Single.builder()
+                    .name(name)
+                    .detail(detail)
+                    .build());
+            }
+        }
 
         @With
         record Single(

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -19,24 +19,27 @@ public interface SubIngredientDto {
 
     interface Bulk {
 
-        @With
-        record Create(
-            List<SubIngredientDto.Create> subIngredients
-        ) {
+        interface Create {
 
-            @Builder
-            public Create(
-                @NotEmpty
-                @Singular
-                    List<SubIngredientDto.Create> subIngredients
+            @With
+            record Single(
+                List<SubIngredientDto.Create.Single> subIngredients
             ) {
-                this.subIngredients = subIngredients;
-            }
 
-            public Set<SubIngredient> asEntity() {
-                return this.subIngredients.stream()
-                    .map(SubIngredientDto.Create::asEntity)
-                    .collect(Collectors.toSet());
+                @Builder
+                public Single(
+                    @NotEmpty
+                    @Singular
+                        List<SubIngredientDto.Create.Single> subIngredients
+                ) {
+                    this.subIngredients = subIngredients;
+                }
+
+                public Set<SubIngredient> asEntity() {
+                    return this.subIngredients.stream()
+                        .map(SubIngredientDto.Create.Single::asEntity)
+                        .collect(Collectors.toSet());
+                }
             }
         }
 
@@ -84,50 +87,54 @@ public interface SubIngredientDto {
         }
     }
 
-    @With
-    record Create(
-        Long recipeId, String name, String detail
-    ) {
+    interface Create {
 
-        @Builder
-        public Create(
-            @NotNull
-                Long recipeId,
+        @With
+        record Single(
+            Long recipeId, String name, String detail
+        ) {
 
-            @NotEmpty
-                String name,
+            @Builder
+            public Single(
+                @NotNull
+                    Long recipeId,
 
-            @NotEmpty
-                String detail) {
-            this.recipeId = recipeId;
-            this.name = name;
-            this.detail = detail;
+                @NotEmpty
+                    String name,
+
+                @NotEmpty
+                    String detail) {
+                this.recipeId = recipeId;
+                this.name = name;
+                this.detail = detail;
+            }
+
+            public SubIngredient asEntity(
+                Function<? super SubIngredient, ? extends SubIngredient> initialize) {
+                return initialize.apply(SubIngredient.builder()
+                    .name(name)
+                    .detail(detail)
+                    .build());
+            }
+
+            public SubIngredient asEntity() {
+                return asEntity(noInit());
+            }
+
+            private <T> Function<? super T, ? extends T> noInit() {
+                return (arg) -> arg;
+            }
+
+            public Single withRecipeId(Long recipeId) {
+                return this.recipeId != null && this.recipeId.equals(recipeId) ? this
+                    : Single.builder()
+                        .recipeId(recipeId)
+                        .name(name)
+                        .detail(detail)
+                        .build();
+            }
+
         }
-
-        public SubIngredient asEntity(
-            Function<? super SubIngredient, ? extends SubIngredient> initialize) {
-            return initialize.apply(SubIngredient.builder()
-                .name(name)
-                .detail(detail)
-                .build());
-        }
-
-        public SubIngredient asEntity() {
-            return asEntity(noInit());
-        }
-
-        private <T> Function<? super T, ? extends T> noInit() {
-            return (arg) -> arg;
-        }
-
-        public Create withRecipeId(Long recipeId) {
-            return this.recipeId != null && this.recipeId.equals(recipeId) ? this : Create.builder()
-                .recipeId(recipeId)
-                .name(name)
-                .detail(detail)
-                .build();
-        }
-
     }
 
     @With

--- a/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/MainIngredientIntegrationTest.java
@@ -2,7 +2,7 @@ package kr.reciptopia.reciptopiaserver;
 
 import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocumentationConfiguration;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.MainIngredientHelper.Bulk.tripleMainIngredientsBulkCreateDto;
 import static kr.reciptopia.reciptopiaserver.helper.MainIngredientHelper.aMainIngredientCreateDto;
@@ -138,7 +138,7 @@ public class MainIngredientIntegrationTest {
             String token = given.valueOf("token");
 
             // When
-            Create dto = Create.builder()
+            Single dto = Single.builder()
                 .recipeId(recipeId)
                 .name("청경채")
                 .detail("500g")
@@ -646,7 +646,7 @@ public class MainIngredientIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleMainIngredientsBulkCreateDto(
+                Bulk.Create.Single dto = tripleMainIngredientsBulkCreateDto(
                     it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.mainIngredients().size();
                 String body = jsonHelper.toJson(dto);
@@ -699,7 +699,7 @@ public class MainIngredientIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleMainIngredientsBulkCreateDto(
+                Bulk.Create.Single dto = tripleMainIngredientsBulkCreateDto(
                     it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.mainIngredients().size();
                 String body = jsonHelper.toJson(dto);

--- a/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
@@ -1,0 +1,155 @@
+package kr.reciptopia.reciptopiaserver;
+
+import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocumentationConfiguration;
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Create;
+import static kr.reciptopia.reciptopiaserver.helper.MainIngredientHelper.Bulk.tripleMainIngredientsBulkCreateWithRecipeDto;
+import static kr.reciptopia.reciptopiaserver.helper.PostHelper.aPostCreateDto;
+import static kr.reciptopia.reciptopiaserver.helper.StepHelper.Bulk.tripleStepsBulkCreateWithRecipeDto;
+import static kr.reciptopia.reciptopiaserver.helper.SubIngredientHelper.Bulk.tripleSubIngredientsBulkCreateWithRecipeDto;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import kr.reciptopia.reciptopiaserver.domain.model.Account;
+import kr.reciptopia.reciptopiaserver.helper.EntityHelper;
+import kr.reciptopia.reciptopiaserver.helper.JsonHelper;
+import kr.reciptopia.reciptopiaserver.helper.Struct;
+import kr.reciptopia.reciptopiaserver.helper.TransactionHelper;
+import kr.reciptopia.reciptopiaserver.helper.auth.PostAuthHelper;
+import kr.reciptopia.reciptopiaserver.util.H2DbCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith(RestDocumentationExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class RecipePostIntegrationTest {
+
+    private static final FieldDescriptor DOC_FIELD_POST =
+        subsectionWithPath("post").type("Post").description("게시글 생성 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_MAIN_INGREDIENT =
+        subsectionWithPath("mainIngredients").type("MainIngredient[]")
+            .description("주 재료 다중 생성 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_SUB_INGREDIENT =
+        subsectionWithPath("subIngredients").type("SubIngredient[]")
+            .description("부 재료 다중 생성 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_STEP =
+        subsectionWithPath("steps").type("Step[]").description("조리 단계 다중 생성 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_BULK_STEPS =
+        subsectionWithPath("bulkStep.steps").type("Map<id, step>").description("조리 단계 수정 필요필드 배열");
+    private static final FieldDescriptor DOC_FIELD_POST_RESPONSE =
+        subsectionWithPath("post").type("Post").description("게시글 조회 결과 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_RECIPE_RESPONSE =
+        subsectionWithPath("recipe").type("Recipe").description("레시피 조회 결과 필드와 동일");
+    private static final FieldDescriptor DOC_FIELD_BULK_MAIN_INGREDIENTS_GRUOP_BY_POST_RESPONSE =
+        subsectionWithPath("bulkMainIngredient.mainIngredients").type("Map<id, mainIngredient>")
+            .description("주 재료의 Id를 Key 로 하고 주 재료 List를 Value 갖는 Map");
+    private static final FieldDescriptor DOC_FIELD_BULK_SUB_INGREDIENTS_RESPONSE =
+        subsectionWithPath("bulkSubIngredient.subIngredients").type("Map<id, subIngredient>")
+            .description("부 재료의 Id를 Key 로 하고 부 재료를 Value 갖는 Map");
+    private static final FieldDescriptor DOC_FIELD_BULK_STEPS_RESPONSE =
+        subsectionWithPath("bulkStep.steps").type("Map<id, step>")
+            .description("조리 단계의 Id를 Key 로 하고 조리 단계를 Value 갖는 Map");
+    @Autowired
+    PasswordEncoder passwordEncoder;
+    private MockMvc mockMvc;
+    @Autowired
+    private JsonHelper jsonHelper;
+    @Autowired
+    private DataSource dataSource;
+    @Autowired
+    private TransactionHelper trxHelper;
+    @Autowired
+    private EntityHelper entityHelper;
+    @Autowired
+    private PostAuthHelper postAuthHelper;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) throws SQLException {
+        H2DbCleaner.clean(dataSource);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
+            .apply(basicDocumentationConfiguration(restDocumentation))
+            .build();
+    }
+
+    @Nested
+    class PostRecipePost {
+
+        @Test
+        void postRecipePost() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account account = entityHelper.generateAccount();
+
+                String token = postAuthHelper.generateToken(account);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("id", account.getId());
+            });
+            String token = given.valueOf("token");
+            Long ownerId = given.valueOf("id");
+
+            // When
+            Create dto = Create.builder()
+                .post(aPostCreateDto(it -> it.withOwnerId(ownerId)))
+                .mainIngredients(tripleMainIngredientsBulkCreateWithRecipeDto())
+                .subIngredients(tripleSubIngredientsBulkCreateWithRecipeDto())
+                .steps(tripleStepsBulkCreateWithRecipeDto())
+                .build();
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/recipePosts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.post.id").isNumber())
+                .andExpect(jsonPath("$.recipe.id").isNumber())
+                .andExpect(jsonPath("$.bulkMainIngredient.mainIngredients").value(aMapWithSize(3)))
+                .andExpect(jsonPath("$.bulkSubIngredient.subIngredients").value(aMapWithSize(3)))
+                .andExpect(jsonPath("$.bulkStep.steps").value(aMapWithSize(3)));
+
+            // Document
+            actions.andDo(document("recipe-post-create-example",
+                requestFields(
+                    DOC_FIELD_POST,
+                    DOC_FIELD_MAIN_INGREDIENT,
+                    DOC_FIELD_SUB_INGREDIENT,
+                    DOC_FIELD_STEP
+                ),
+                responseFields(
+                    DOC_FIELD_POST_RESPONSE,
+                    DOC_FIELD_RECIPE_RESPONSE,
+                    DOC_FIELD_BULK_MAIN_INGREDIENTS_GRUOP_BY_POST_RESPONSE,
+                    DOC_FIELD_BULK_SUB_INGREDIENTS_RESPONSE,
+                    DOC_FIELD_BULK_STEPS_RESPONSE
+                )));
+        }
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/StepIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/StepIntegrationTest.java
@@ -2,7 +2,7 @@ package kr.reciptopia.reciptopiaserver;
 
 import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocumentationConfiguration;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Bulk;
-import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.StepHelper.Bulk.tripleStepsBulkCreateDto;
 import static kr.reciptopia.reciptopiaserver.helper.StepHelper.aStepCreateDto;
@@ -31,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import kr.reciptopia.reciptopiaserver.docs.ApiDocumentation;
+import kr.reciptopia.reciptopiaserver.domain.dto.StepDto;
 import kr.reciptopia.reciptopiaserver.domain.model.Recipe;
 import kr.reciptopia.reciptopiaserver.domain.model.Step;
 import kr.reciptopia.reciptopiaserver.helper.EntityHelper;
@@ -125,7 +126,7 @@ public class StepIntegrationTest {
             String token = given.valueOf("token");
 
             // When
-            Create dto = Create.builder()
+            Single dto = StepDto.Create.Single.builder()
                 .recipeId(recipeId)
                 .description("고춧가루 2수저 가득, 청정원 고추장 1수저 가득, "
                     + "청정원 양조간장 3수저, 맛술 1수저, 설탕 2수저, "
@@ -474,7 +475,7 @@ public class StepIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleStepsBulkCreateDto(it -> it.withRecipeId(recipeId));
+                Bulk.Create.Single dto = tripleStepsBulkCreateDto(it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.steps().size();
                 String body = jsonHelper.toJson(dto);
 
@@ -528,7 +529,7 @@ public class StepIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleStepsBulkCreateDto(it -> it.withRecipeId(recipeId));
+                Bulk.Create.Single dto = tripleStepsBulkCreateDto(it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.steps().size();
                 String body = jsonHelper.toJson(dto);
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
@@ -1,7 +1,7 @@
 package kr.reciptopia.reciptopiaserver;
 
 import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocumentationConfiguration;
-import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.SubIngredientHelper.Bulk.tripleSubIngredientsBulkCreateDto;
 import static kr.reciptopia.reciptopiaserver.helper.SubIngredientHelper.aSubIngredientCreateDto;
@@ -134,7 +134,7 @@ public class SubIngredientIntegrationTest {
             String token = given.valueOf("token");
 
             // When
-            Create dto = Create.builder()
+            Single dto = kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single.builder()
                 .recipeId(recipeId)
                 .name("간장")
                 .detail("한 큰술")
@@ -476,7 +476,7 @@ public class SubIngredientIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleSubIngredientsBulkCreateDto(
+                Bulk.Create.Single dto = tripleSubIngredientsBulkCreateDto(
                     it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.subIngredients().size();
                 String body = jsonHelper.toJson(dto);
@@ -530,7 +530,7 @@ public class SubIngredientIntegrationTest {
                 String token = given.valueOf("token");
 
                 // When
-                Bulk.Create dto = tripleSubIngredientsBulkCreateDto(
+                Bulk.Create.Single dto = tripleSubIngredientsBulkCreateDto(
                     it -> it.withRecipeId(recipeId));
                 int dtoNumber = dto.subIngredients().size();
                 String body = jsonHelper.toJson(dto);

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
@@ -45,6 +45,13 @@ public class MainIngredientHelper {
         return aMainIngredientCreateDto(noInit());
     }
 
+    public static MainIngredientDto.Create.WithRecipe aMainIngredientCreateWithRecipeDto() {
+        return MainIngredientDto.Create.WithRecipe.builder()
+            .name(ARBITRARY_NAME)
+            .detail(ARBITRARY_DETAIL)
+            .build();
+    }
+
     public static Update aMainIngredientUpdateDto() {
         return Update.builder()
             .name(ARBITRARY_NAME)
@@ -78,6 +85,14 @@ public class MainIngredientHelper {
 
         static MainIngredientDto.Bulk.Create.Single tripleMainIngredientsBulkCreateDto() {
             return tripleMainIngredientsBulkCreateDto(noInit());
+        }
+
+        static MainIngredientDto.Bulk.Create.WithRecipe tripleMainIngredientsBulkCreateWithRecipeDto() {
+            return MainIngredientDto.Bulk.Create.WithRecipe.builder()
+                .mainIngredient(MainIngredientHelper.aMainIngredientCreateWithRecipeDto())
+                .mainIngredient(MainIngredientHelper.aMainIngredientCreateWithRecipeDto())
+                .mainIngredient(MainIngredientHelper.aMainIngredientCreateWithRecipeDto())
+                .build();
         }
 
         static MainIngredientDto.Bulk.Update tripleMainIngredientsBulkUpdateDto() {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/MainIngredientHelper.java
@@ -1,6 +1,6 @@
 package kr.reciptopia.reciptopiaserver.helper;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.RecipeHelper.aRecipe;
@@ -28,20 +28,20 @@ public class MainIngredientHelper {
             .withId(ARBITRARY_ID);
     }
 
-    public static Create aMainIngredientCreateDto(
-        Function<? super Create, ? extends Create> initialize) {
-        Create createDto = Create.builder()
+    public static Single aMainIngredientCreateDto(
+        Function<? super Single, ? extends Single> initialize) {
+        Single singleDto = MainIngredientDto.Create.Single.builder()
             .build();
 
-        createDto = initialize.apply(createDto);
-        return Create.builder()
-            .recipeId(createDto.recipeId() == null ? ARBITRARY_RECIPE_ID : createDto.recipeId())
+        singleDto = initialize.apply(singleDto);
+        return MainIngredientDto.Create.Single.builder()
+            .recipeId(singleDto.recipeId() == null ? ARBITRARY_RECIPE_ID : singleDto.recipeId())
             .name(ARBITRARY_NAME)
             .detail(ARBITRARY_DETAIL)
             .build();
     }
 
-    public static Create aMainIngredientCreateDto() {
+    public static Single aMainIngredientCreateDto() {
         return aMainIngredientCreateDto(noInit());
     }
 
@@ -67,16 +67,16 @@ public class MainIngredientHelper {
 
     public interface Bulk {
 
-        static MainIngredientDto.Bulk.Create tripleMainIngredientsBulkCreateDto(
-            Function<? super Create, ? extends Create> initialize) {
-            return MainIngredientDto.Bulk.Create.builder()
+        static MainIngredientDto.Bulk.Create.Single tripleMainIngredientsBulkCreateDto(
+            Function<? super Single, ? extends Single> initialize) {
+            return MainIngredientDto.Bulk.Create.Single.builder()
                 .mainIngredient(MainIngredientHelper.aMainIngredientCreateDto(initialize))
                 .mainIngredient(MainIngredientHelper.aMainIngredientCreateDto(initialize))
                 .mainIngredient(MainIngredientHelper.aMainIngredientCreateDto(initialize))
                 .build();
         }
 
-        static MainIngredientDto.Bulk.Create tripleMainIngredientsBulkCreateDto() {
+        static MainIngredientDto.Bulk.Create.Single tripleMainIngredientsBulkCreateDto() {
             return tripleMainIngredientsBulkCreateDto(noInit());
         }
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostHelper.java
@@ -1,12 +1,16 @@
 package kr.reciptopia.reciptopiaserver.helper;
 
+import static kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Create;
 import static kr.reciptopia.reciptopiaserver.helper.AccountHelper.anAccount;
 
+import java.util.function.Function;
 import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Update;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 
 public class PostHelper {
 
+    private static final Long ARBITRARY_ID = 0L;
+    private static final Long ARBITRARY_OWNER_ID = 4L;
     private static final String ARBITRARY_TITLE = "가문어 오징어 튀김 만들기";
     private static final String ARBITRARY_CONTENT = "가문어 오징어 다리를 잘라서 튀긴다.";
     private static final String ARBITRARY_PICTURE_URL_1 = "C:\\Users\\eunsung\\Desktop\\temp\\picture";
@@ -21,7 +25,21 @@ public class PostHelper {
             .pictureUrl(ARBITRARY_PICTURE_URL_1)
             .pictureUrl(ARBITRARY_PICTURE_URL_2)
             .build()
-            .withId(0L);
+            .withId(ARBITRARY_ID);
+    }
+
+    public static Create aPostCreateDto(Function<? super Create, ? extends Create> initialize) {
+        Create createDto = Create.builder()
+            .build();
+
+        createDto = initialize.apply(createDto);
+        return Create.builder()
+            .ownerId(createDto.ownerId() == null ? ARBITRARY_OWNER_ID : createDto.ownerId())
+            .title(ARBITRARY_TITLE)
+            .content(ARBITRARY_CONTENT)
+            .pictureUrl(ARBITRARY_PICTURE_URL_1)
+            .pictureUrl(ARBITRARY_PICTURE_URL_2)
+            .build();
     }
 
     public static Update aPostUpdateDto() {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/StepHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/StepHelper.java
@@ -1,6 +1,7 @@
 package kr.reciptopia.reciptopiaserver.helper;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create.Single;
+import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create.WithRecipe;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.RecipeHelper.aRecipe;
@@ -32,11 +33,11 @@ public class StepHelper {
     }
 
     public static Single aStepCreateDto(Function<? super Single, ? extends Single> initialize) {
-        Single singleDto = StepDto.Create.Single.builder()
+        Single singleDto = Single.builder()
             .build();
 
         singleDto = initialize.apply(singleDto);
-        return StepDto.Create.Single.builder()
+        return Single.builder()
             .recipeId(singleDto.recipeId() == null ? ARBITRARY_RECIPE_ID : singleDto.recipeId())
             .description(ARBITRARY_DESCRIPTION)
             .pictureUrl(ARBITRARY_URL)
@@ -45,6 +46,13 @@ public class StepHelper {
 
     public static Single aStepCreateDto() {
         return aStepCreateDto(noInit());
+    }
+
+    public static WithRecipe aStepCreateWithRecipeDto() {
+        return WithRecipe.builder()
+            .description(ARBITRARY_DESCRIPTION)
+            .pictureUrl(ARBITRARY_URL)
+            .build();
     }
 
     public static Update aStepUpdateDto() {
@@ -80,6 +88,14 @@ public class StepHelper {
 
         static StepDto.Bulk.Create.Single tripleStepsBulkCreateDto() {
             return tripleStepsBulkCreateDto(noInit());
+        }
+
+        static StepDto.Bulk.Create.WithRecipe tripleStepsBulkCreateWithRecipeDto() {
+            return StepDto.Bulk.Create.WithRecipe.builder()
+                .step(StepHelper.aStepCreateWithRecipeDto())
+                .step(StepHelper.aStepCreateWithRecipeDto())
+                .step(StepHelper.aStepCreateWithRecipeDto())
+                .build();
         }
 
         static StepDto.Bulk.Update tripleStepsBulkUpdateDto() {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/StepHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/StepHelper.java
@@ -1,6 +1,6 @@
 package kr.reciptopia.reciptopiaserver.helper;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.StepDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.RecipeHelper.aRecipe;
@@ -31,19 +31,19 @@ public class StepHelper {
             .withId(ARBITRARY_RECIPE_ID);
     }
 
-    public static Create aStepCreateDto(Function<? super Create, ? extends Create> initialize) {
-        Create createDto = Create.builder()
+    public static Single aStepCreateDto(Function<? super Single, ? extends Single> initialize) {
+        Single singleDto = StepDto.Create.Single.builder()
             .build();
 
-        createDto = initialize.apply(createDto);
-        return Create.builder()
-            .recipeId(createDto.recipeId() == null ? ARBITRARY_RECIPE_ID : createDto.recipeId())
+        singleDto = initialize.apply(singleDto);
+        return StepDto.Create.Single.builder()
+            .recipeId(singleDto.recipeId() == null ? ARBITRARY_RECIPE_ID : singleDto.recipeId())
             .description(ARBITRARY_DESCRIPTION)
             .pictureUrl(ARBITRARY_URL)
             .build();
     }
 
-    public static Create aStepCreateDto() {
+    public static Single aStepCreateDto() {
         return aStepCreateDto(noInit());
     }
 
@@ -69,16 +69,16 @@ public class StepHelper {
 
     public interface Bulk {
 
-        static StepDto.Bulk.Create tripleStepsBulkCreateDto(
-            Function<? super Create, ? extends Create> initialize) {
-            return StepDto.Bulk.Create.builder()
+        static StepDto.Bulk.Create.Single tripleStepsBulkCreateDto(
+            Function<? super Single, ? extends Single> initialize) {
+            return StepDto.Bulk.Create.Single.builder()
                 .step(StepHelper.aStepCreateDto(initialize))
                 .step(StepHelper.aStepCreateDto(initialize))
                 .step(StepHelper.aStepCreateDto(initialize))
                 .build();
         }
 
-        static StepDto.Bulk.Create tripleStepsBulkCreateDto() {
+        static StepDto.Bulk.Create.Single tripleStepsBulkCreateDto() {
             return tripleStepsBulkCreateDto(noInit());
         }
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/SubIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/SubIngredientHelper.java
@@ -1,9 +1,10 @@
 package kr.reciptopia.reciptopiaserver.helper;
 
-import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create;
+import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Update;
 import static kr.reciptopia.reciptopiaserver.helper.RecipeHelper.aRecipe;
+
 import java.util.function.Function;
 import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto;
 import kr.reciptopia.reciptopiaserver.domain.model.SubIngredient;
@@ -27,20 +28,20 @@ public class SubIngredientHelper {
             .withId(ARBITRARY_ID);
     }
 
-    public static Create aSubIngredientCreateDto(
-        Function<? super Create, ? extends Create> initialize) {
-        Create createDto = Create.builder()
+    public static Single aSubIngredientCreateDto(
+        Function<? super Single, ? extends Single> initialize) {
+        Single singleDto = SubIngredientDto.Create.Single.builder()
             .build();
 
-        createDto = initialize.apply(createDto);
-        return Create.builder()
-            .recipeId(createDto.recipeId() == null ? ARBITRARY_RECIPE_ID : createDto.recipeId())
+        singleDto = initialize.apply(singleDto);
+        return SubIngredientDto.Create.Single.builder()
+            .recipeId(singleDto.recipeId() == null ? ARBITRARY_RECIPE_ID : singleDto.recipeId())
             .name(ARBITRARY_NAME)
             .detail(ARBITRARY_DETAIL)
             .build();
     }
 
-    public static Create aSubIngredientCreateDto() {
+    public static Single aSubIngredientCreateDto() {
         return aSubIngredientCreateDto(noInit());
     }
 
@@ -66,16 +67,16 @@ public class SubIngredientHelper {
 
     public interface Bulk {
 
-        static SubIngredientDto.Bulk.Create tripleSubIngredientsBulkCreateDto(
-            Function<? super Create, ? extends Create> initialize) {
-            return SubIngredientDto.Bulk.Create.builder()
+        static SubIngredientDto.Bulk.Create.Single tripleSubIngredientsBulkCreateDto(
+            Function<? super Single, ? extends Single> initialize) {
+            return SubIngredientDto.Bulk.Create.Single.builder()
                 .subIngredient(SubIngredientHelper.aSubIngredientCreateDto(initialize))
                 .subIngredient(SubIngredientHelper.aSubIngredientCreateDto(initialize))
                 .subIngredient(SubIngredientHelper.aSubIngredientCreateDto(initialize))
                 .build();
         }
 
-        static SubIngredientDto.Bulk.Create tripleSubIngredientsBulkCreateDto() {
+        static SubIngredientDto.Bulk.Create.Single tripleSubIngredientsBulkCreateDto() {
             return tripleSubIngredientsBulkCreateDto(noInit());
         }
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/SubIngredientHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/SubIngredientHelper.java
@@ -45,6 +45,13 @@ public class SubIngredientHelper {
         return aSubIngredientCreateDto(noInit());
     }
 
+    public static SubIngredientDto.Create.WithRecipe aSubIngredientCreateWithRecipeDto() {
+        return SubIngredientDto.Create.WithRecipe.builder()
+            .name(ARBITRARY_NAME)
+            .detail(ARBITRARY_DETAIL)
+            .build();
+    }
+
     public static Update aSubIngredientUpdateDto() {
         return Update.builder()
             .name(ARBITRARY_NAME)
@@ -78,6 +85,14 @@ public class SubIngredientHelper {
 
         static SubIngredientDto.Bulk.Create.Single tripleSubIngredientsBulkCreateDto() {
             return tripleSubIngredientsBulkCreateDto(noInit());
+        }
+
+        static SubIngredientDto.Bulk.Create.WithRecipe tripleSubIngredientsBulkCreateWithRecipeDto() {
+            return SubIngredientDto.Bulk.Create.WithRecipe.builder()
+                .subIngredient(SubIngredientHelper.aSubIngredientCreateWithRecipeDto())
+                .subIngredient(SubIngredientHelper.aSubIngredientCreateWithRecipeDto())
+                .subIngredient(SubIngredientHelper.aSubIngredientCreateWithRecipeDto())
+                .build();
         }
 
         static SubIngredientDto.Bulk.Update tripleSubIngredientsBulkUpdateDto() {


### PR DESCRIPTION
`Recipe` 와 `MainIngredient` , `SubIngredient`  및 `Step` 들이 존재하는 
일반적인 `Post` 를 생성하기위한 클라이언트의 기존의 생성 요청횟수를 줄이기 위해서  
`RecipePost` 을 통한 일괄적인 생성요청을 API를 추가