### PR TITLE
PostLikeTag 의 통합 테스트의 테스트 케이스 및 Helper 클래스 수정

### DIFF
--- a/src/test/java/kr/reciptopia/reciptopiaserver/PostLikeTagIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/PostLikeTagIntegrationTest.java
@@ -229,7 +229,7 @@ public class PostLikeTagIntegrationTest {
 
             // Then
             actions
-                .andExpect(status().isNotFound());
+                .andExpect(status().isBadRequest());
         }
 
         @Test
@@ -259,7 +259,7 @@ public class PostLikeTagIntegrationTest {
 
             // Then
             actions
-                .andExpect(status().isNotFound());
+                .andExpect(status().isBadRequest());
         }
     }
 

--- a/src/test/java/kr/reciptopia/reciptopiaserver/PostLikeTagIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/PostLikeTagIntegrationTest.java
@@ -186,10 +186,9 @@ public class PostLikeTagIntegrationTest {
             Long postId = given.valueOf("postId");
 
             // When
-            Create dto = aPostLikeTagCreateDto(it -> it
+            Create dto = aPostLikeTagCreateDto()
                 .withOwnerId(-1L)
-                .withPostId(postId)
-            );
+                .withPostId(postId);
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post("/post/likeTags")
@@ -218,10 +217,9 @@ public class PostLikeTagIntegrationTest {
             Long postId = given.valueOf("postId");
 
             // When
-            Create dto = aPostLikeTagCreateDto(it -> it
+            Create dto = aPostLikeTagCreateDto()
                 .withOwnerId(null)
-                .withPostId(postId)
-            );
+                .withPostId(postId);
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post("/post/likeTags")
@@ -249,10 +247,9 @@ public class PostLikeTagIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            Create dto = aPostLikeTagCreateDto(it -> it
+            Create dto = aPostLikeTagCreateDto()
                 .withOwnerId(ownerId)
-                .withPostId(null)
-            );
+                .withPostId(null);
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post("/post/likeTags")

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostLikeTagHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostLikeTagHelper.java
@@ -2,12 +2,9 @@ package kr.reciptopia.reciptopiaserver.helper;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.PostLikeTagDto.Create;
 import static kr.reciptopia.reciptopiaserver.domain.dto.PostLikeTagDto.Result;
-import static kr.reciptopia.reciptopiaserver.domain.dto.helper.InitializationHelper.noInit;
 import static kr.reciptopia.reciptopiaserver.helper.AccountHelper.anAccount;
 import static kr.reciptopia.reciptopiaserver.helper.PostHelper.aPost;
-import static kr.reciptopia.reciptopiaserver.helper.fieldfilter.FilterHelper.getNonNull;
 
-import java.util.function.Function;
 import kr.reciptopia.reciptopiaserver.domain.model.PostLikeTag;
 
 public class PostLikeTagHelper {
@@ -24,20 +21,11 @@ public class PostLikeTagHelper {
             .withId(ARBITRARY_ID);
     }
 
-    public static Create aPostLikeTagCreateDto(
-        Function<? super Create, ? extends Create> initialize) {
-        Create createDto = Create.builder()
-            .build();
-
-        createDto = initialize.apply(createDto);
-        return Create.builder()
-            .ownerId(getNonNull(createDto.ownerId(), ARBITRARY_OWNER_ID))
-            .postId(getNonNull(createDto.postId(), ARBITRARY_POST_ID))
-            .build();
-    }
-
     public static Create aPostLikeTagCreateDto() {
-        return aPostLikeTagCreateDto(noInit());
+        return Create.builder()
+            .ownerId(ARBITRARY_OWNER_ID)
+            .postId(ARBITRARY_POST_ID)
+            .build();
     }
 
     public static Result aPostLikeTagResultDto() {


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] PostLikeTagHelper 클래스 수정

- [x] PostLikeTag 통합 테스트 검증로직 수정

---

# 📝Memo


[최근 수정된](fix_post_like_tag_dto_validation_issue) Helper 클래스 중 `CreateDto` 에 해당하는 의 메소드가 

`with` 애노테이션의 메소드의 불변객체에 대한 특정 필드 수정을 담당하는 기능과 중복되므로 

해당 메소드를 삭제하고 with 애노테이션의 기능을 적절히 활용하도록 수정