### PR TITLE
RecipePostDto 리펙토링

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
@@ -7,24 +7,14 @@ import lombok.With;
 public interface RecipePostDto {
 
     @With
+    @Builder
     record Create(
-        PostDto.Create post, MainIngredientDto.Bulk.Create.WithRecipe mainIngredients,
-        SubIngredientDto.Bulk.Create.WithRecipe subIngredients, StepDto.Bulk.Create.WithRecipe steps
+        @NotNull PostDto.Create post,
+        MainIngredientDto.Bulk.Create.WithRecipe mainIngredients,
+        SubIngredientDto.Bulk.Create.WithRecipe subIngredients,
+        StepDto.Bulk.Create.WithRecipe steps
     ) {
 
-        @Builder
-        public Create(
-            @NotNull
-                PostDto.Create post,
-
-            MainIngredientDto.Bulk.Create.WithRecipe mainIngredients,
-            SubIngredientDto.Bulk.Create.WithRecipe subIngredients,
-            StepDto.Bulk.Create.WithRecipe steps) {
-            this.post = post;
-            this.mainIngredients = mainIngredients;
-            this.subIngredients = subIngredients;
-            this.steps = steps;
-        }
     }
 
     @With

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/RecipePostDto.java
@@ -18,14 +18,11 @@ public interface RecipePostDto {
     }
 
     @With
+    @Builder
     record Result(
         PostDto.Result post, RecipeDto.Result recipe,
         MainIngredientDto.Bulk.ResultGroupBy.Id bulkMainIngredient,
         SubIngredientDto.Bulk.Result bulkSubIngredient, StepDto.Bulk.Result bulkStep
     ) {
-
-        @Builder
-        public Result {
-        }
     }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
@@ -2,10 +2,8 @@ package kr.reciptopia.reciptopiaserver;
 
 import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocumentationConfiguration;
 import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Create;
-import static kr.reciptopia.reciptopiaserver.helper.MainIngredientHelper.Bulk.tripleMainIngredientsBulkCreateWithRecipeDto;
 import static kr.reciptopia.reciptopiaserver.helper.PostHelper.aPostCreateDto;
-import static kr.reciptopia.reciptopiaserver.helper.StepHelper.Bulk.tripleStepsBulkCreateWithRecipeDto;
-import static kr.reciptopia.reciptopiaserver.helper.SubIngredientHelper.Bulk.tripleSubIngredientsBulkCreateWithRecipeDto;
+import static kr.reciptopia.reciptopiaserver.helper.RecipePostHelper.aRecipePostCreateDto;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -111,12 +109,11 @@ public class RecipePostIntegrationTest {
             Long ownerId = given.valueOf("id");
 
             // When
-            Create dto = Create.builder()
-                .post(aPostCreateDto(it -> it.withOwnerId(ownerId)))
-                .mainIngredients(tripleMainIngredientsBulkCreateWithRecipeDto())
-                .subIngredients(tripleSubIngredientsBulkCreateWithRecipeDto())
-                .steps(tripleStepsBulkCreateWithRecipeDto())
-                .build();
+            Create dto = aRecipePostCreateDto()
+                .withPost(aPostCreateDto()
+                    .withOwnerId(ownerId)
+                );
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post("/recipePosts")

--- a/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/RecipePostIntegrationTest.java
@@ -146,5 +146,64 @@ public class RecipePostIntegrationTest {
                     DOC_FIELD_BULK_STEPS_RESPONSE
                 )));
         }
+
+        @Test
+        void post가_없는_recipe_post_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+
+                String token = postAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token);
+            });
+            String token = given.valueOf("token");
+
+            // When
+            Create dto = aRecipePostCreateDto()
+                .withPost(null);
+
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/recipePosts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 존재하지않는_owner_id로_recipe_post_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+
+                String token = postAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token);
+            });
+            String token = given.valueOf("token");
+
+            // When
+            Create dto = aRecipePostCreateDto()
+                .withPost(aPostCreateDto()
+                    .withOwnerId(-1L)
+                );
+
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/recipePosts")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isNotFound());
+        }
+
     }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/PostHelper.java
@@ -2,7 +2,7 @@ package kr.reciptopia.reciptopiaserver.helper;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Create;
 import static kr.reciptopia.reciptopiaserver.helper.AccountHelper.anAccount;
-import java.util.function.Function;
+
 import kr.reciptopia.reciptopiaserver.domain.dto.PostDto.Update;
 import kr.reciptopia.reciptopiaserver.domain.model.Post;
 
@@ -23,13 +23,9 @@ public class PostHelper {
             .withId(ARBITRARY_ID);
     }
 
-    public static Create aPostCreateDto(Function<? super Create, ? extends Create> initialize) {
-        Create createDto = Create.builder()
-            .build();
-
-        createDto = initialize.apply(createDto);
+    public static Create aPostCreateDto() {
         return Create.builder()
-            .ownerId(createDto.ownerId() == null ? ARBITRARY_OWNER_ID : createDto.ownerId())
+            .ownerId(ARBITRARY_OWNER_ID)
             .title(ARBITRARY_TITLE)
             .content(ARBITRARY_CONTENT)
             .build();

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/RecipePostHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/RecipePostHelper.java
@@ -1,0 +1,36 @@
+package kr.reciptopia.reciptopiaserver.helper;
+
+import static kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto.Create;
+import static kr.reciptopia.reciptopiaserver.helper.MainIngredientHelper.Bulk.tripleMainIngredientsBulkCreateWithRecipeDto;
+import static kr.reciptopia.reciptopiaserver.helper.PostHelper.aPostCreateDto;
+import static kr.reciptopia.reciptopiaserver.helper.StepHelper.Bulk.tripleStepsBulkCreateWithRecipeDto;
+import static kr.reciptopia.reciptopiaserver.helper.SubIngredientHelper.Bulk.tripleSubIngredientsBulkCreateWithRecipeDto;
+
+import kr.reciptopia.reciptopiaserver.domain.dto.MainIngredientDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.PostDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.StepDto;
+import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto;
+
+public class RecipePostHelper {
+
+
+    private static final PostDto.Create
+        ARBITRARY_POST = aPostCreateDto();
+    private static final MainIngredientDto.Bulk.Create.WithRecipe
+        ARBITRARY_MAIN_INGREDIENTS = tripleMainIngredientsBulkCreateWithRecipeDto();
+    private static final SubIngredientDto.Bulk.Create.WithRecipe
+        ARBITRARY_SUB_INGREDIENTS = tripleSubIngredientsBulkCreateWithRecipeDto();
+    private static final StepDto.Bulk.Create.WithRecipe
+        ARBITRARY_STEPS = tripleStepsBulkCreateWithRecipeDto();
+
+
+    public static Create aRecipePostCreateDto() {
+        return Create.builder()
+            .post(ARBITRARY_POST)
+            .mainIngredients(ARBITRARY_MAIN_INGREDIENTS)
+            .subIngredients(ARBITRARY_SUB_INGREDIENTS)
+            .steps(ARBITRARY_STEPS)
+            .build();
+    }
+
+}


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] RecipePostDto  Bean Validation 수정

- [x] RecipePostDto Builder 애노테이션 수정 및 생성자 수정 

- [x] RecipePostHelper 추가

- [x] RecipePost 통합 테스트 검증로직 수정 및 추가

- [x] RecipePost 통합 테스트 검증로직 수정

---

# 📝Memo


기존 `record` 에 적용되어 있었던  `Bean Validation` 이 적절하지 못한 위치에서 선언되어 

해당 `Bean Validation`  이 적용되지 않고 있었던 버그 수정을 위한 리펙토링과

해당 `Bean Validation`  에 대한 검증로직 추가


또한 `Bean Validation` 의 위치가 변경됨에 따라 

DTO의 생성자를 Compact 하게 만들 수 있고, 해당 생성자를 생략함으로써

Builder 애노테이션의 위치를 수정


[이전에 수정된](21ce86435c4257bd5239b059dd7eba998d2a211b) Helper 클래스 중 `CreateDto` 에 해당하는 의 메소드가 

`with` 애노테이션의 메소드의 불변객체에 대한 특정 필드 수정을 담당하는 기능과 중복되므로 

해당 메소드를 삭제하고 `with` 애노테이션의 기능을 적절히 활용하도록 수정