### PR TITLE
Post Search 문제 수정

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
@@ -1,8 +1,5 @@
 package kr.reciptopia.reciptopiaserver.business.service;
 
-import static kr.reciptopia.reciptopiaserver.business.service.searchcondition.PostSearchCondition.getRecipeSearchCondition;
-import static kr.reciptopia.reciptopiaserver.business.service.searchcondition.PostSearchCondition.updateConditionWithRecipeCondition;
-
 import java.util.List;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.PostAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
@@ -61,10 +58,10 @@ public class PostService {
 
     public Bulk.ResultWithCommentAndLikeTagCount search(PostSearchCondition condition,
         Pageable pageable) {
-        RecipeSearchCondition recipeSearchCondition = getRecipeSearchCondition(condition);
+        RecipeSearchCondition recipeSearchCondition = condition.getRecipeSearchCondition();
         List<Long> postIds = getPostIdsFromRecipeCondition(pageable, recipeSearchCondition);
         PageImpl<Post> posts = postRepositoryImpl.search(
-            updateConditionWithRecipeCondition(condition, recipeSearchCondition, postIds),
+            condition.updateConditionWithRecipeCondition(recipeSearchCondition, postIds),
             pageable);
 
         return Bulk.ResultWithCommentAndLikeTagCount.of(

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/PostService.java
@@ -1,5 +1,6 @@
 package kr.reciptopia.reciptopiaserver.business.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.PostAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
@@ -58,11 +59,21 @@ public class PostService {
 
     public Bulk.ResultWithCommentAndLikeTagCount search(PostSearchCondition condition,
         Pageable pageable) {
+
         RecipeSearchCondition recipeSearchCondition = condition.getRecipeSearchCondition();
-        List<Long> postIds = getPostIdsFromRecipeCondition(pageable, recipeSearchCondition);
-        PageImpl<Post> posts = postRepositoryImpl.search(
-            condition.updateConditionWithRecipeCondition(recipeSearchCondition, postIds),
-            pageable);
+        PageImpl<Post> posts = new PageImpl<>(new ArrayList<>());
+
+        if (!recipeSearchCondition.isEmptyCondition()) {
+
+            List<Long> postIds = getPostIdsFromRecipeCondition(pageable, recipeSearchCondition);
+
+            if (!postIds.isEmpty()) {
+                PostSearchCondition updatedCondition =
+                    condition.updateConditionWithRecipeCondition(recipeSearchCondition, postIds);
+                posts = postRepositoryImpl.search(updatedCondition, pageable);
+            }
+        } else
+            posts = postRepositoryImpl.search(condition, pageable);
 
         return Bulk.ResultWithCommentAndLikeTagCount.of(
             posts,

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/PostSearchCondition.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/PostSearchCondition.java
@@ -23,34 +23,32 @@ public record PostSearchCondition(
 	}
 
 
-	public static RecipeSearchCondition getRecipeSearchCondition(
-		PostSearchCondition postSearchCondition) {
-		return RecipeSearchCondition.builder()
-			.mainIngredientNames(postSearchCondition.mainIngredientNames())
-			.subIngredientNames(postSearchCondition.subIngredientNames()).build();
-	}
+	public RecipeSearchCondition getRecipeSearchCondition() {
+        return RecipeSearchCondition.builder()
+            .mainIngredientNames(this.mainIngredientNames())
+            .subIngredientNames(this.subIngredientNames()).build();
+    }
 
-	private static PostSearchCondition withIds(PostSearchCondition condition, List<Long> ids) {
-		return PostSearchCondition.builder()
-			.ownerId(condition.ownerId())
-			.titleLike(condition.titleLike())
-			.mainIngredientNames(condition.mainIngredientNames())
-			.subIngredientNames(condition.subIngredientNames())
-			.ids(ids)
-			.build();
-	}
+    private PostSearchCondition withIds(List<Long> ids) {
+        return PostSearchCondition.builder()
+            .ownerId(this.ownerId())
+            .titleLike(this.titleLike())
+            .mainIngredientNames(this.mainIngredientNames())
+            .subIngredientNames(this.subIngredientNames())
+            .ids(ids)
+            .build();
+    }
 
-	public static PostSearchCondition updateConditionWithRecipeCondition(
-		PostSearchCondition condition,
-		RecipeSearchCondition recipeSearchCondition, List<Long> postIds) {
-		if (!recipeSearchCondition.isEmpty()) {
-			List<Long> conditionIds = condition.ids();
-			if (!conditionIds.isEmpty())
-				conditionIds.retainAll(postIds);
-			else
-				conditionIds = postIds;
-			condition = withIds(condition, conditionIds);
-		}
-		return condition;
+    public PostSearchCondition updateConditionWithRecipeCondition(
+        RecipeSearchCondition recipeSearchCondition, List<Long> postIds) {
+        if (!recipeSearchCondition.isEmpty()) {
+            List<Long> conditionIds = this.ids();
+            if (!this.ids().isEmpty())
+                conditionIds.retainAll(postIds);
+            else
+                conditionIds = postIds;
+            return this.withIds(conditionIds);
+        }
+        return this;
 	}
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/RecipeSearchCondition.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/searchcondition/RecipeSearchCondition.java
@@ -24,4 +24,12 @@ public record RecipeSearchCondition(
     public boolean isEmpty() {
         return this.mainIngredientNames.isEmpty() && this.subIngredientNames.isEmpty();
     }
+
+    public boolean isEmptyCondition() {
+        return this.mainIngredientNames.isEmpty() &&
+            this.subIngredientNames.isEmpty() &&
+            this.ids.isEmpty() &&
+            this.postIds.isEmpty();
+
+    }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/PostIntegrationTest.java
@@ -759,6 +759,71 @@ public class PostIntegrationTest {
         }
 
         @Test
+        void 일치하는_recipe를_갖는_post가_없는_mainIngredients로_post검색() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipeA = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeA));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeA));
+
+                Recipe recipeB = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeB));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeB));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeB));
+
+                Recipe recipeC = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("양파")
+                        .withRecipe(recipeC));
+
+                Recipe recipeD = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeD));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeD));
+
+                Recipe recipeE = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeE));
+                return new Struct()
+                    .withValue("postBId", recipeB.getPost().getId())
+                    .withValue("postCId", recipeC.getPost().getId());
+            });
+
+            // When
+            ResultActions actions = mockMvc.perform(get("/posts")
+                .param("mainIngredientNames", "딸기, 당근, 수박")
+            );
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.postWithCommentAndLikeTagCounts").value(aMapWithSize(0)));
+        }
+
+        @Test
         void id들과_mainIngredients로_post검색() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/RecipeIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/RecipeIntegrationTest.java
@@ -416,6 +416,73 @@ public class RecipeIntegrationTest {
         }
 
         @Test
+        void 일치하는_recipe가_없는_mainIngredients로_reicpe검색() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipeA = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeA));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeA));
+
+                Recipe recipeB = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeB));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeB));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeB));
+
+                Recipe recipeC = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeC));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("양파")
+                        .withRecipe(recipeC));
+
+                Recipe recipeD = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("감자")
+                        .withRecipe(recipeD));
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("고추장")
+                        .withRecipe(recipeD));
+
+                Recipe recipeE = entityHelper.generateRecipe();
+                entityHelper.generateMainIngredient(
+                    ig -> ig.withName("닭다리")
+                        .withRecipe(recipeE));
+                return new Struct()
+                    .withValue("recipeBId", recipeB.getId())
+                    .withValue("recipeCId", recipeC.getId());
+            });
+            Long recipeBId = given.valueOf("recipeBId");
+            Long recipeCId = given.valueOf("recipeCId");
+
+            // When
+            ResultActions actions = mockMvc.perform(get("/post/recipes")
+                .param("mainIngredientNames", "딸기, 수박, 참외")
+            );
+
+            // Then
+            actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.recipes").value(aMapWithSize(0)));
+        }
+
+        @Test
         void subIngredients로_정렬() throws Exception {
             // Given
             Struct given = trxHelper.doInTransaction(() -> {


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] Post 통합 테스트의 케이스 추가

- [x] Post 검색 비즈니스 로직 수정

- [x] Recipe 통합 테스트의 케이스 추가

- [x] PostSearchCondition 리펙토링

---

# 📝Memo


`Post` 의 검색 비즈니로 로직 특성상 

`Recipe` 의 검색 비즈니스 로직에 의존적인데

`MainIngredient` 필드 와 같이 

`PostSearchCondition` 에 존재하는 필드가 포함된 검색의 경우

`RecipeService` 의 검색 비즈니스로직을 직접 사용하여

해당 검색결과로써 일치하는 `Post` 들의 `id` 를 갖고 오고

해당 `postId` 들을 기존의 `PostSearchCondition` 에 추가하여 

`Post` 의 검색 비즈니스 로직을 통해 검색하는 것이 

`Post` 의 검색 비즈니스 로직이다.



그러나 이때 클라이언트가 요청한

`PostSearchCondition` 에 존재하는 비어있지 않은 검색필드가 

`RecipeSearchCondition` 의 필드에 부분집합일 경우 중에서

해당 필드로 `RecipeService` 의 검색 비즈니스로직을 직접 사용하여

해당 검색결과로써 일치하는 `Post` 들이 존재 하지 않는 경우,

위의 아무것도 존재하지 않는 `postId` 들이 추가되면

`PostSearchCondition` 의 모든 필드는 비어있게 되고

이는 마치 아무런 매개변수를 넣지 않은 `Post` 검색 요청과 같아지고

이에 따라 모든 `Post` 들이 나오는 버그였으므로

`Post` 의 검색 비즈니스에 `PostSearchCondition` 과 

그로 인해 만들어진 `RecipeSearchCondition` 의 필드 상태에 따라

분기를 설정하여 해결했다.
