### PR TITLE
ReplyDto 리펙토링

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/ReplyService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/ReplyService.java
@@ -2,6 +2,7 @@ package kr.reciptopia.reciptopiaserver.business.service;
 
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.ReplyAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.ReplySearchCondition;
 import kr.reciptopia.reciptopiaserver.domain.dto.ReplyDto.Bulk;
 import kr.reciptopia.reciptopiaserver.domain.dto.ReplyDto.Create;
@@ -28,6 +29,7 @@ public class ReplyService {
     private final ReplyRepositoryImpl replyRepositoryImpl;
     private final RepositoryHelper repoHelper;
     private final ReplyAuthorizer replyAuthorizer;
+    private final ServiceErrorHelper errorHelper;
 
     @Transactional
     public Result create(Create dto, Authentication authentication) {
@@ -58,6 +60,7 @@ public class ReplyService {
         replyAuthorizer.requireReplyOwner(authentication, reply);
 
         if (dto.content() != null) {
+            throwExceptionWhenBlankContent(dto.content());
             reply.setContent(dto.content());
         }
 
@@ -70,5 +73,12 @@ public class ReplyService {
         replyAuthorizer.requireReplyOwner(authentication, reply);
 
         ReplyRepository.delete(reply);
+    }
+
+    public void throwExceptionWhenBlankContent(String content) {
+        if (content.isBlank()) {
+            throw errorHelper.badRequest(
+                "Content must not be null and must contain at least one non-whitespace character");
+        }
     }
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
@@ -72,14 +72,11 @@ public interface ReplyDto {
     }
 
     @With
-    record Update(String content) {
+    @Builder
+    record Update(
+        @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
+        String content) {
 
-        @Builder
-        public Update(
-            @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
-                String content) {
-            this.content = content;
-        }
     }
 
     @With

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
@@ -80,28 +80,14 @@ public interface ReplyDto {
     }
 
     @With
+    @Builder
     record Result(
-        Long id, Long ownerId, Long commentId, String content) {
-
-        @Builder
-        public Result(
-            @NotNull
-                Long id,
-
-            @NotNull
-                Long ownerId,
-
-            @NotNull
-                Long commentId,
-
-            @NotBlank
-            @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
-                String content) {
-            this.id = id;
-            this.ownerId = ownerId;
-            this.commentId = commentId;
-            this.content = content;
-        }
+        @NotNull Long id,
+        @NotNull Long ownerId,
+        @NotNull Long commentId,
+        @NotBlank
+        @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
+        String content) {
 
         public static Result of(Reply entity) {
             return Result.builder()

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
@@ -1,8 +1,8 @@
 package kr.reciptopia.reciptopiaserver.domain.dto;
 
+import static kr.reciptopia.reciptopiaserver.domain.dto.helper.CollectorHelper.byLinkedHashMapWithKey;
 import static kr.reciptopia.reciptopiaserver.domain.dto.helper.InitializationHelper.noInit;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -23,28 +23,21 @@ public interface ReplyDto {
     interface Bulk {
 
         @With
-        record Result(Map<Long, ReplyDto.Result> replies) {
+        record Result(@NotEmpty Map<Long, ReplyDto.Result> replies) {
 
             @Builder
             public Result(
-                @NotEmpty
                 @Singular
-                    Map<Long, ReplyDto.Result> replies
+                Map<Long, ReplyDto.Result> replies
             ) {
                 this.replies = replies;
             }
 
             public static Result of(Page<Reply> replies) {
                 return Result.builder()
-                    .replies((Map<? extends Long, ? extends ReplyDto.Result>) replies.stream()
+                    .replies(replies.stream()
                         .map(ReplyDto.Result::of)
-                        .collect(
-                            Collectors.toMap(
-                                ReplyDto.Result::id,
-                                result -> result,
-                                (x, y) -> y,
-                                LinkedHashMap::new
-                            )))
+                        .collect(byLinkedHashMapWithKey(ReplyDto.Result::id)))
                     .build();
             }
         }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyDto.java
@@ -51,24 +51,13 @@ public interface ReplyDto {
     }
 
     @With
+    @Builder
     record Create(
-        Long ownerId, Long commentId, String content) {
-
-        @Builder
-        public Create(
-            @NotNull
-                Long ownerId,
-
-            @NotNull
-                Long commentId,
-
-            @NotBlank
-            @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
-                String content) {
-            this.ownerId = ownerId;
-            this.commentId = commentId;
-            this.content = content;
-        }
+        @NotNull Long ownerId,
+        @NotNull Long commentId,
+        @NotBlank
+        @Size(min = 1, max = 50, message = "content는 1 ~ 50자 이여야 합니다!")
+        String content) {
 
         public Reply asEntity(
             Function<? super Reply, ? extends Reply> initialize) {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/ReplyIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/ReplyIntegrationTest.java
@@ -169,6 +169,219 @@ public class ReplyIntegrationTest {
                 .andExpect(status().isNotFound());
         }
 
+        @Test
+        void 존재하지않는_owner_id로_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+                Comment comment = entityHelper.generateComment();
+
+                String token = replyAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentId", comment.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentId = given.valueOf("commentId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withOwnerId(-1L)
+                .withCommentId(commentId);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void owner_id가_없는_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+                Comment comment = entityHelper.generateComment();
+
+                String token = replyAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentId", comment.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentId = given.valueOf("commentId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withOwnerId(null)
+                .withCommentId(commentId);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 존재하지않는_comment_id로_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+
+                String token = replyAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("ownerId", owner.getId());
+            });
+            String token = given.valueOf("token");
+            Long ownerId = given.valueOf("ownerId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withOwnerId(ownerId)
+                .withCommentId(-1L);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void comment_id가_없는_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Account owner = entityHelper.generateAccount();
+
+                String token = replyAuthHelper.generateToken(owner);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("ownerId", owner.getId());
+            });
+            String token = given.valueOf("token");
+            Long ownerId = given.valueOf("ownerId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withOwnerId(ownerId)
+                .withCommentId(null);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void content가_없는_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Comment comment = entityHelper.generateComment();
+
+                String token = replyAuthHelper.generateToken(comment);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentId", comment.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentId = given.valueOf("commentId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withCommentId(commentId)
+                .withContent(null);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 공백으로_채워진_content로_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Comment comment = entityHelper.generateComment();
+
+                String token = replyAuthHelper.generateToken(comment);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentId", comment.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentId = given.valueOf("commentId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withCommentId(commentId)
+                .withContent("      ");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 너무_긴_길이의_content로_reply_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Comment comment = entityHelper.generateComment();
+
+                String token = replyAuthHelper.generateToken(comment);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("commentId", comment.getId());
+            });
+            String token = given.valueOf("token");
+            Long commentId = given.valueOf("commentId");
+
+            // When
+            Create dto = aReplyCreateDto()
+                .withCommentId(commentId)
+                .withContent("And_so_I_wake_in_the_morning_and_I_step_Outside_"
+                    + "and_I_take_a_deep_breath_And_I_get_real_high_"
+                    + "Then_I_scream_from_the_top_of_my_lungs_What's_goin_on");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/comment/replies")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
     }
 
     @Nested

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/ReplyAuthHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/auth/ReplyAuthHelper.java
@@ -5,7 +5,7 @@ import kr.reciptopia.reciptopiaserver.domain.model.Reply;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ReplyAuthHelper extends AuthHelper {
+public class ReplyAuthHelper extends CommentAuthHelper {
 
     public ReplyAuthHelper(JwtService jwtService) {
         super(jwtService);


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] ReplyDto   Bean Validation 수정

- [x] ReplyDto Builder 애노테이션 수정 및 생성자 수정 

- [x] ReplyService 검증로직 추가

- [x] Reply 통합 테스트 검증로직 추가

---

# 📝Memo


기존 `record` 에 적용되어 있었던  `Bean Validation` 이 적절하지 못한 위치에서 선언되어 

해당 `Bean Validation`  이 적용되지 않고 있었던 버그 수정을 위한 리펙토링과

해당 `Bean Validation`  에 대한 검증로직 추가


또한 `Bean Validation` 의 위치가 변경됨에 따라 

DTO의 생성자를 Compact 하게 만들 수 있고, 해당 생성자를 생략함으로써

Builder 애노테이션의 위치를 수정


`update DTO` 의 특성상 해당 필드가

수정하지 않는 필드일 경우 null 값이 들어가게 되므로

null 이 아닐때 빈 공백으로 이루어져 있는지

검사하는 로직이 별도록 필요하여

해당 로직을 Service 계층에 추가

그러나 해당 로직은 타 엔티티의 검증요소가

추가됨에따라 코드 중복의 우려가 있으므로

추후 리펙토링 예정