### PR TITLE
ReplyLikeTagDto 리펙토링

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyLikeTagDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyLikeTagDto.java
@@ -14,29 +14,20 @@ import org.springframework.data.util.Streamable;
 public interface ReplyLikeTagDto {
 
 	@With
-	record Create(
-		Long ownerId, Long replyId) {
+    @Builder
+    record Create(
+        @NotNull Long ownerId,
+        @NotNull Long replyId) {
 
-		@Builder
-		public Create(
-			@NotNull
-				Long ownerId,
+        public ReplyLikeTag asEntity(
+            Function<? super ReplyLikeTag, ? extends ReplyLikeTag> initialize) {
+            return initialize.apply(ReplyLikeTag.builder().build());
+        }
 
-			@NotNull
-				Long replyId) {
-			this.ownerId = ownerId;
-			this.replyId = replyId;
-		}
-
-		public ReplyLikeTag asEntity(
-			Function<? super ReplyLikeTag, ? extends ReplyLikeTag> initialize) {
-			return initialize.apply(ReplyLikeTag.builder().build());
-		}
-
-		public ReplyLikeTag asEntity() {
-			return asEntity(noInit());
-		}
-	}
+        public ReplyLikeTag asEntity() {
+            return asEntity(noInit());
+        }
+    }
 
 	@With
 	record Result(

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyLikeTagDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/ReplyLikeTagDto.java
@@ -30,33 +30,21 @@ public interface ReplyLikeTagDto {
     }
 
 	@With
-	record Result(
-		Long id, Long ownerId, Long replyId) {
+    @Builder
+    record Result(
+        @NotNull Long id,
+        @NotNull Long ownerId,
+        @NotNull Long replyId) {
 
-		@Builder
-		public Result(
-			@NotNull
-				Long id,
+        public static Result of(ReplyLikeTag entity) {
+            return Result.builder()
+                .id(entity.getId())
+                .ownerId(entity.getOwner().getId())
+                .replyId(entity.getReply().getId())
+                .build();
+        }
 
-			@NotNull
-				Long ownerId,
-
-			@NotNull
-				Long replyId) {
-			this.id = id;
-			this.ownerId = ownerId;
-			this.replyId = replyId;
-		}
-
-		public static Result of(ReplyLikeTag entity) {
-			return Result.builder()
-				.id(entity.getId())
-				.ownerId(entity.getOwner().getId())
-				.replyId(entity.getReply().getId())
-				.build();
-		}
-
-		public static List<Result> of(Streamable<ReplyLikeTag> entities) {
+        public static List<Result> of(Streamable<ReplyLikeTag> entities) {
 			return entities.stream()
 				.map(Result::of)
 				.collect(Collectors.toList());


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] ReplyLikeTagDto   Bean Validation 수정

- [x] ReplyLikeTagDto Builder 애노테이션 수정 및 생성자 수정 

- [x] Reply 통합 테스트 검증로직 추가

---

# 📝Memo


기존 `record` 에 적용되어 있었던  `Bean Validation` 이 적절하지 못한 위치에서 선언되어 

해당 `Bean Validation`  이 적용되지 않고 있었던 버그 수정을 위한 리펙토링과

해당 `Bean Validation`  에 대한 검증로직 추가


또한 `Bean Validation` 의 위치가 변경됨에 따라 

DTO의 생성자를 Compact 하게 만들 수 있고, 해당 생성자를 생략함으로써

Builder 애노테이션의 위치를 수정
