### PR TITLE
SearchHistoryDto 리펙토링

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
@@ -24,12 +24,11 @@ public interface SearchHistoryDto {
 
         @With
         record Result(
-            Map<Long, SearchHistoryDto.Result> searchHistories
+            @NotEmpty Map<Long, SearchHistoryDto.Result> searchHistories
         ) {
 
             @Builder
             public Result(
-                @NotEmpty
                 @Singular
                     Map<Long, SearchHistoryDto.Result> searchHistories
             ) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
@@ -81,13 +81,16 @@ public interface SearchHistoryDto {
 
     @With
     record Result(
-        Long id, Long ownerId, Set<String> ingredientNames, LocalDateTime createdDate
+        @NotNull Long id,
+        @NotNull Long ownerId,
+        Set<String> ingredientNames,
+        @NotNull LocalDateTime createdDate
     ) {
 
         @Builder
         public Result(
-            @NotNull Long id,
-            @NotNull Long ownerId,
+            Long id,
+            Long ownerId,
             @Singular Set<String> ingredientNames,
             LocalDateTime createdDate) {
             this.id = id;

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
@@ -1,9 +1,9 @@
 package kr.reciptopia.reciptopiaserver.domain.dto;
 
+import static kr.reciptopia.reciptopiaserver.domain.dto.helper.CollectorHelper.byLinkedHashMapWithKey;
 import static kr.reciptopia.reciptopiaserver.domain.dto.helper.InitializationHelper.noInit;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,15 +37,9 @@ public interface SearchHistoryDto {
 
             public static Result of(Page<SearchHistory> searchHistories) {
                 return Result.builder()
-                    .searchHistories(
-                        (Map<? extends Long, ? extends SearchHistoryDto.Result>) searchHistories.stream()
-                            .map(SearchHistoryDto.Result::of)
-                            .collect(
-                                Collectors.toMap(
-                                    SearchHistoryDto.Result::id,
-                                    result -> result,
-                                    (x, y) -> y,
-                                    LinkedHashMap::new)))
+                    .searchHistories(searchHistories.stream()
+                        .map(SearchHistoryDto.Result::of)
+                        .collect(byLinkedHashMapWithKey(SearchHistoryDto.Result::id)))
                     .build();
             }
         }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SearchHistoryDto.java
@@ -55,16 +55,14 @@ public interface SearchHistoryDto {
 
     @With
     record Create(
-        Long ownerId, Set<String> ingredientNames
+        @NotNull Long ownerId, Set<String> ingredientNames
     ) {
 
         @Builder
         public Create(
-            @NotNull
-                Long ownerId,
-
+            Long ownerId,
             @Singular
-                Set<String> ingredientNames) {
+            Set<String> ingredientNames) {
             this.ownerId = ownerId;
             this.ingredientNames = ingredientNames;
         }


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] SearchHistoryDto Bean Validation 수정

- [x] Reply 통합 테스트 검증로직 추가

---

# 📝Memo


기존 `record` 에 적용되어 있었던  `Bean Validation` 이 적절하지 못한 위치에서 선언되어 

해당 `Bean Validation`  이 적용되지 않고 있었던 버그 수정을 위한 리펙토링과

해당 `Bean Validation`  에 대한 검증로직 추가

또한 SearchHistoryDto.Bulk.Result 의 of 메소드 를

`CollectorHelper` 의 메소드를 사용하여 중복을 줄이도록 리펙토링


