### PR TITLE
Account 통합테스트 리펙토링

### DIFF
--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -157,6 +157,15 @@ public class AccountIntegrationTest {
         return MockHttpServletRequestBuilderHelper.get(baseUrl);
     }
 
+    private MockHttpServletRequestBuilder patch(Long id, String token,
+        String body) {
+        return MockHttpServletRequestBuilderHelper.patch(idUrl, id, token, body);
+    }
+
+    private MockHttpServletRequestBuilder patch(String body, Long id) {
+        return MockHttpServletRequestBuilderHelper.patch(idUrl, id, body);
+    }
+
     @Nested
     class PostAccount {
 
@@ -501,10 +510,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(id, token, body));
 
             // Then
             MvcResult mvcResult = actions
@@ -540,9 +547,8 @@ public class AccountIntegrationTest {
             // When
             String body = jsonHelper.toJson(anAccountUpdateDto());
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", 0)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(body, 0L));
 
             // Then
             actions
@@ -576,10 +582,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", ownerId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(ownerId, token, body));
 
             // Then
             MvcResult mvcResult = actions
@@ -635,10 +639,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(id, token, body));
 
             // Then
             actions
@@ -672,10 +674,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(id, token, body));
 
             // Then
             actions
@@ -710,10 +710,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(id, token, body));
 
             // Then
             actions
@@ -747,10 +745,8 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(patch("/accounts/{id}", id)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer " + token)
-                .content(body));
+            ResultActions actions = mockMvc.perform(
+                patch(id, token, body));
 
             // Then
             actions

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,6 +51,7 @@ import kr.reciptopia.reciptopiaserver.helper.auth.PostAuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.auth.ReplyAuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.auth.SearchHistoryAuthHelper;
 import kr.reciptopia.reciptopiaserver.helper.auth.UploadFileAuthHelper;
+import kr.reciptopia.reciptopiaserver.helper.integrationtest.MockHttpServletRequestBuilderHelper;
 import kr.reciptopia.reciptopiaserver.persistence.repository.AccountProfileImgRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.AccountRepository;
 import kr.reciptopia.reciptopiaserver.persistence.repository.CommentLikeTagRepository;
@@ -78,6 +78,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -131,6 +132,8 @@ public class AccountIntegrationTest {
     @Autowired
     PasswordEncoder passwordEncoder;
 
+    private static final String baseUrl = "/accounts";
+
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext,
         RestDocumentationContextProvider restDocumentation) throws SQLException {
@@ -140,6 +143,10 @@ public class AccountIntegrationTest {
             .apply(springSecurity())
             .apply(basicDocumentationConfiguration(restDocumentation))
             .build();
+    }
+
+    private MockHttpServletRequestBuilder post(String body) {
+        return MockHttpServletRequestBuilderHelper.post(baseUrl, body);
     }
 
     @Nested
@@ -155,9 +162,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             MvcResult mvcResult = actions
@@ -195,9 +200,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             actions
@@ -214,9 +217,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             actions
@@ -233,9 +234,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             actions
@@ -253,9 +252,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             actions
@@ -272,9 +269,7 @@ public class AccountIntegrationTest {
                 .build();
             String body = jsonHelper.toJson(dto);
 
-            ResultActions actions = mockMvc.perform(post("/accounts")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(body));
+            ResultActions actions = mockMvc.perform(post(body));
 
             // Then
             actions

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -153,6 +153,10 @@ public class AccountIntegrationTest {
         return MockHttpServletRequestBuilderHelper.get(idUrl, id);
     }
 
+    private MockHttpServletRequestBuilder search() {
+        return MockHttpServletRequestBuilderHelper.get(baseUrl);
+    }
+
     @Nested
     class PostAccount {
 
@@ -352,7 +356,7 @@ public class AccountIntegrationTest {
             Long accountBId = given.valueOf("accountBId");
 
             // When
-            ResultActions actions = mockMvc.perform(get("/accounts"));
+            ResultActions actions = mockMvc.perform(search());
 
             // Then
             actions
@@ -394,7 +398,7 @@ public class AccountIntegrationTest {
             Long accountCId = given.valueOf("accountCId");
 
             // When
-            ResultActions actions = mockMvc.perform(get("/accounts")
+            ResultActions actions = mockMvc.perform(search()
                 .param("size", "2")
                 .param("page", "1")
                 .param("sort", "id,desc"));
@@ -440,7 +444,7 @@ public class AccountIntegrationTest {
 
             // When
             String postIdsParam = postBId + ", " + postCId + ", " + postEId;
-            ResultActions actions = mockMvc.perform(get("/accounts")
+            ResultActions actions = mockMvc.perform(search()
                 .param("postIds", postIdsParam));
 
             // Then

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -286,7 +286,7 @@ public class AccountIntegrationTest {
             // When
             Create dto = anAccountCreateDto()
                 .withNickname("        ");
-            
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));
@@ -637,9 +637,9 @@ public class AccountIntegrationTest {
             Long id = given.valueOf("id");
 
             // When
-            Update dto = Update.builder()
-                .email("new_email_com")
-                .build();
+            Update dto = anAccountUpdateDto()
+                .withEmail("new_bad_email_com");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(
@@ -672,9 +672,9 @@ public class AccountIntegrationTest {
             Long id = given.valueOf("id");
 
             // When
-            Update dto = Update.builder()
-                .password("short")
-                .build();
+            Update dto = anAccountUpdateDto()
+                .withPassword("short");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(
@@ -707,10 +707,11 @@ public class AccountIntegrationTest {
             Long id = given.valueOf("id");
 
             // When
-            Update dto = Update.builder()
-                .nickname(
-                    "And_so_I_wake_in_the_morning_and_I_step_Outside_and_I_take_a_deep_breath_And_I_get_real_high_Then_I_scream_from_the_top_of_my_lungs_What's_goin_on")
-                .build();
+            Update dto = anAccountUpdateDto()
+                .withNickname("And_so_I_wake_in_the_morning_and_I_step_Outside_"
+                    + "and_I_take_a_deep_breath_And_I_get_real_high_"
+                    + "Then_I_scream_from_the_top_of_my_lungs_What's_goin_on");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(
@@ -743,9 +744,9 @@ public class AccountIntegrationTest {
             Long id = given.valueOf("id");
 
             // When
-            Update dto = Update.builder()
-                .nickname("          ")
-                .build();
+            Update dto = anAccountUpdateDto()
+                .withNickname("          ");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -133,6 +132,7 @@ public class AccountIntegrationTest {
     PasswordEncoder passwordEncoder;
 
     private static final String baseUrl = "/accounts";
+    private static final String idUrl = baseUrl + "/{id}";
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext,
@@ -147,6 +147,10 @@ public class AccountIntegrationTest {
 
     private MockHttpServletRequestBuilder post(String body) {
         return MockHttpServletRequestBuilderHelper.post(baseUrl, body);
+    }
+
+    private MockHttpServletRequestBuilder get(Long id) {
+        return MockHttpServletRequestBuilderHelper.get(idUrl, id);
     }
 
     @Nested
@@ -296,7 +300,7 @@ public class AccountIntegrationTest {
 
             // When
             ResultActions actions = mockMvc
-                .perform(get("/accounts/{id}", id));
+                .perform(get(id));
 
             // Then
             actions
@@ -321,7 +325,7 @@ public class AccountIntegrationTest {
         @Test
         void getAccount_AccountNotFound_NotFoundStatus() throws Exception {
             // When
-            ResultActions actions = mockMvc.perform(get("/accounts/{id}", 0L));
+            ResultActions actions = mockMvc.perform(get(0L));
 
             // Then
             actions

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -18,8 +18,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.subsecti
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,7 +66,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
@@ -133,6 +130,7 @@ public class AccountIntegrationTest {
 
     private static final String baseUrl = "/accounts";
     private static final String idUrl = baseUrl + "/{id}";
+    private static final String emailExistUrl = baseUrl + "/{email}/exists";
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext,
@@ -172,6 +170,10 @@ public class AccountIntegrationTest {
 
     private MockHttpServletRequestBuilder delete() {
         return MockHttpServletRequestBuilderHelper.delete(idUrl, 0L);
+    }
+
+    private MockHttpServletRequestBuilder checkDuplicateUsername(String email) {
+        return MockHttpServletRequestBuilderHelper.get(emailExistUrl, email);
     }
 
     @Nested
@@ -1444,7 +1446,8 @@ public class AccountIntegrationTest {
         @Test
         void 중복되지_않는_email_중복확인조회() throws Exception {
             //When
-            ResultActions actions = mockMvc.perform(get("/accounts/{email}/exists", "newUser"));
+            ResultActions actions = mockMvc.perform(
+                checkDuplicateUsername("newUser"));
 
             //Then
             actions
@@ -1467,8 +1470,8 @@ public class AccountIntegrationTest {
             });
 
             // When
-            ResultActions actions = mockMvc.perform(get("/accounts/{email}/exists",
-                email));
+            ResultActions actions = mockMvc.perform(
+                checkDuplicateUsername(email));
 
             // Then
             actions

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -166,6 +166,14 @@ public class AccountIntegrationTest {
         return MockHttpServletRequestBuilderHelper.patch(idUrl, id, body);
     }
 
+    private MockHttpServletRequestBuilder delete(Long id, String token) {
+        return MockHttpServletRequestBuilderHelper.delete(idUrl, id, token);
+    }
+
+    private MockHttpServletRequestBuilder delete() {
+        return MockHttpServletRequestBuilderHelper.delete(idUrl, 0L);
+    }
+
     @Nested
     class PostAccount {
 
@@ -772,8 +780,8 @@ public class AccountIntegrationTest {
             Long id = given.valueOf("id");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", id)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(id, token));
 
             // Then
             actions
@@ -789,7 +797,8 @@ public class AccountIntegrationTest {
         @Test
         void deleteAccount_AccountNotFound_NotFound_Status() throws Exception {
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", 0L));
+            ResultActions actions = mockMvc.perform(
+                delete());
 
             // Then
             actions
@@ -816,8 +825,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -855,8 +864,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -891,8 +900,8 @@ public class AccountIntegrationTest {
             Long postId = given.valueOf("postId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -931,8 +940,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -967,8 +976,8 @@ public class AccountIntegrationTest {
             Long commentId = given.valueOf("commentId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1007,8 +1016,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1043,8 +1052,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1083,8 +1092,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1116,8 +1125,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1155,8 +1164,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1191,8 +1200,8 @@ public class AccountIntegrationTest {
             Long postId = given.valueOf("postId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1231,8 +1240,8 @@ public class AccountIntegrationTest {
             Long ownerId = given.valueOf("ownerId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1268,8 +1277,8 @@ public class AccountIntegrationTest {
             Long commentLikeTagId = given.valueOf("commentLikeTagId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1307,8 +1316,8 @@ public class AccountIntegrationTest {
             Long commentLikeTagBId = given.valueOf("commentLikeTagBId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1343,8 +1352,8 @@ public class AccountIntegrationTest {
             Long replyLikeTagId = given.valueOf("replyLikeTagId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1382,8 +1391,8 @@ public class AccountIntegrationTest {
             Long replyLikeTagBId = given.valueOf("replyLikeTagBId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions
@@ -1415,8 +1424,8 @@ public class AccountIntegrationTest {
             Long accountProfileImgId = given.valueOf("accountProfileImgId");
 
             // When
-            ResultActions actions = mockMvc.perform(delete("/accounts/{id}", ownerId)
-                .header("Authorization", "Bearer " + token));
+            ResultActions actions = mockMvc.perform(
+                delete(ownerId, token));
 
             // Then
             actions

--- a/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/AccountIntegrationTest.java
@@ -4,6 +4,7 @@ import static kr.reciptopia.reciptopiaserver.docs.ApiDocumentation.basicDocument
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Create;
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.AccountDto.Update;
+import static kr.reciptopia.reciptopiaserver.helper.AccountHelper.anAccountCreateDto;
 import static kr.reciptopia.reciptopiaserver.helper.AccountHelper.anAccountUpdateDto;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
@@ -221,10 +222,9 @@ public class AccountIntegrationTest {
         @Test
         void email이_없는_account_생성() throws Exception {
             // When
-            Create dto = Create.builder()
-                .password("this!sPassw0rd")
-                .nickname("pte1024")
-                .build();
+            Create dto = anAccountCreateDto()
+                .withEmail(null);
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));
@@ -237,11 +237,9 @@ public class AccountIntegrationTest {
         @Test
         void email_형식이_아닌_account_생성() throws Exception {
             // When
-            Create dto = Create.builder()
-                .email("invalid_email_com")
-                .password("this!sPassw0rd")
-                .nickname("pte1024")
-                .build();
+            Create dto = anAccountCreateDto()
+                .withEmail("invalid_email_com");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));
@@ -254,11 +252,9 @@ public class AccountIntegrationTest {
         @Test
         void 너무_짧은_길이의_password로_account_생성() throws Exception {
             // When
-            Create dto = Create.builder()
-                .email("test@email.com")
-                .password("bad")
-                .nickname("pte1024")
-                .build();
+            Create dto = anAccountCreateDto()
+                .withPassword("bad");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));
@@ -271,12 +267,11 @@ public class AccountIntegrationTest {
         @Test
         void 너무_긴_길이의_nickname으로_account_생성() throws Exception {
             // When
-            Create dto = Create.builder()
-                .email("test@email.com")
-                .password("this!sPassw0rd")
-                .nickname(
-                    "And_so_I_wake_in_the_morning_and_I_step_Outside_and_I_take_a_deep_breath_And_I_get_real_high_Then_I_scream_from_the_top_of_my_lungs_What's_goin_on")
-                .build();
+            Create dto = anAccountCreateDto()
+                .withNickname("And_so_I_wake_in_the_morning_and_I_step_Outside_"
+                    + "and_I_take_a_deep_breath_And_I_get_real_high_"
+                    + "Then_I_scream_from_the_top_of_my_lungs_What's_goin_on");
+
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));
@@ -289,11 +284,9 @@ public class AccountIntegrationTest {
         @Test
         void 공백으로_채워진_nickname으로_account_생성() throws Exception {
             // When
-            Create dto = Create.builder()
-                .email("test@email.com")
-                .password("this!sPassw0rd")
-                .nickname("        ")
-                .build();
+            Create dto = anAccountCreateDto()
+                .withNickname("        ");
+            
             String body = jsonHelper.toJson(dto);
 
             ResultActions actions = mockMvc.perform(post(body));

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -31,4 +31,13 @@ public class MockHttpServletRequestBuilderHelper {
             .contentType(MediaType.APPLICATION_JSON)
             .content(body);
     }
+
+    public static MockHttpServletRequestBuilder delete(String url, Long id, String token) {
+        return delete(url, id)
+            .header("Authorization", "Bearer " + token);
+    }
+
+    public static MockHttpServletRequestBuilder delete(String url, Long id) {
+        return MockMvcRequestBuilders.delete(url, id);
+    }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -1,0 +1,14 @@
+package kr.reciptopia.reciptopiaserver.helper.integrationtest;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class MockHttpServletRequestBuilderHelper {
+
+    public static MockHttpServletRequestBuilder post(String url, String body) {
+        return MockMvcRequestBuilders.post(url)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body);
+    }
+}

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -11,4 +11,8 @@ public class MockHttpServletRequestBuilderHelper {
             .contentType(MediaType.APPLICATION_JSON)
             .content(body);
     }
+
+    public static MockHttpServletRequestBuilder get(String url, Long id) {
+        return MockMvcRequestBuilders.get(url, id);
+    }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -20,6 +20,10 @@ public class MockHttpServletRequestBuilderHelper {
         return MockMvcRequestBuilders.get(url, id);
     }
 
+    public static MockHttpServletRequestBuilder get(String url, String email) {
+        return MockMvcRequestBuilders.get(url, email);
+    }
+
     public static MockHttpServletRequestBuilder patch(String url, Long id, String token,
         String body) {
         return patch(url, id, body)

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -19,4 +19,16 @@ public class MockHttpServletRequestBuilderHelper {
     public static MockHttpServletRequestBuilder get(String url, Long id) {
         return MockMvcRequestBuilders.get(url, id);
     }
+
+    public static MockHttpServletRequestBuilder patch(String url, Long id, String token,
+        String body) {
+        return patch(url, id, body)
+            .header("Authorization", "Bearer " + token);
+    }
+
+    public static MockHttpServletRequestBuilder patch(String url, Long id, String body) {
+        return MockMvcRequestBuilders.patch(url, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body);
+    }
 }

--- a/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/helper/integrationtest/MockHttpServletRequestBuilderHelper.java
@@ -12,6 +12,10 @@ public class MockHttpServletRequestBuilderHelper {
             .content(body);
     }
 
+    public static MockHttpServletRequestBuilder get(String url) {
+        return MockMvcRequestBuilders.get(url);
+    }
+
     public static MockHttpServletRequestBuilder get(String url, Long id) {
         return MockMvcRequestBuilders.get(url, id);
     }


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] Account 통합 테스트 Mock Url 추상화

- [x] Account 통합 테스트 중 부정 테스트 리펙토링

---

# 📝Memo


논제의 요지는 테스트를 위한 객체 생성시 필드의 노출 범위에 대한 것입니다.

* 아래의 DTO 필드의 BeanValidation 긍정 테스트 메소드들의 일부분입니다. 

![image](https://user-images.githubusercontent.com/37146362/195024854-c4cd30b3-1e13-40f0-b5b6-6bb45bf9fb94.png)
 

정상적인 생성 결과에 대한 테스트는 생성 전과 후의 데이터의 비교를 통해 

테스트 결과가 기대와 맞게 생성되었는지 검사를 진행하게 됩니다. 


이 경우 테스트용 객체의 필드의 명시적인 표시로 가독성을 높혀주어 

해당 테스트의 목적성을 빠르게 파악할 수 있습니다.
 

물론 모든 테스트의 경우가 그러한 것은 아닙니다. 

* 아래는 DTO 필드의 BeanValidation 부정 테스트 메소드들의 일부분입니다.    

![image](https://user-images.githubusercontent.com/37146362/195024752-a83090f4-ba90-47ad-ae7a-ea3e146035a2.png)


위와 같은 특정 필드의 유효성 중 부정 검사 테스트에 사용되는 DTO 객체는 

검사 대상 필드를 제외한 다른 필드엔 정상적인 값이 들어가 있어야 하며, 

검사 대상이 아니기에 다소 관심밖의 영역에 있으므로 

해당 필드에 대해 관심도를 줄이기 위해 동일한 값으로 이루어져 있습니다.


그러나 이 방법으로는 코드의 중복을 줄일 수 없을 뿐 더러 

필드에 대한 관심도를 줄였다곤 하나 여전히 명시적인 필드로써 가독성을 저해하고 있습니다.


따라서 이를 추가적인 Helper 메소드를 구현하여 아래와 같이

![image](https://user-images.githubusercontent.com/37146362/195025041-1ce5e107-414d-4e4d-88c5-6a4d1adeee6e.png)

 
검증 필드만을 명시적인 필드로 남기게 하여 

테스트코드의 가독성과 유지보수성을 확보하는 것이 목적입니다.
