### PR TITLE
SubIngredientDto 리펙토링

### DIFF
--- a/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/business/service/SubIngredientService.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import kr.reciptopia.reciptopiaserver.business.service.authorizer.IngredientAuthorizer;
 import kr.reciptopia.reciptopiaserver.business.service.helper.RepositoryHelper;
+import kr.reciptopia.reciptopiaserver.business.service.helper.ServiceErrorHelper;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.SubIngredientSearchCondition;
 import kr.reciptopia.reciptopiaserver.domain.dto.RecipeDto;
 import kr.reciptopia.reciptopiaserver.domain.dto.RecipePostDto;
@@ -31,6 +32,7 @@ public class SubIngredientService {
     private final SubIngredientRepositoryImpl subIngredientRepositoryImpl;
     private final RepositoryHelper repoHelper;
     private final IngredientAuthorizer ingredientAuthorizer;
+    private final ServiceErrorHelper errorHelper;
 
     @Transactional
     public Result create(Single dto, Authentication authentication) {
@@ -56,12 +58,13 @@ public class SubIngredientService {
         ingredientAuthorizer.requireIngredientOwner(authentication, subIngredient);
 
         if (dto.name() != null) {
+            throwExceptionWhenBlankName(dto.name());
             subIngredient.setName(dto.name());
         }
         if (dto.detail() != null) {
+            throwExceptionWhenBlankDetail(dto.detail());
             subIngredient.setDetail(dto.detail());
         }
-
         return Result.of(subIngredientRepository.save(subIngredient));
     }
 
@@ -106,4 +109,18 @@ public class SubIngredientService {
         ids.forEach(id -> delete(id, authentication));
     }
 
+
+    public void throwExceptionWhenBlankName(String name) {
+        if (name.isBlank()) {
+            throw errorHelper.badRequest(
+                "Name must not be null and must contain at least one non-whitespace character");
+        }
+    }
+
+    public void throwExceptionWhenBlankDetail(String detail) {
+        if (detail.isBlank()) {
+            throw errorHelper.badRequest(
+                "Detail must not be null and must contain at least one non-whitespace character");
+        }
+    }
 }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/controller/SubIngredientController.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/controller/SubIngredientController.java
@@ -1,13 +1,12 @@
 package kr.reciptopia.reciptopiaserver.controller;
 
+import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Result;
 import static kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Update;
-
 import java.util.Set;
 import javax.validation.Valid;
 import kr.reciptopia.reciptopiaserver.business.service.SubIngredientService;
 import kr.reciptopia.reciptopiaserver.business.service.searchcondition.SubIngredientSearchCondition;
-import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto;
 import kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Bulk;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -33,7 +32,7 @@ public class SubIngredientController {
 
     @PostMapping("/post/recipe/subIngredients")
     @ResponseStatus(HttpStatus.CREATED)
-    public Result post(@Valid @RequestBody SubIngredientDto.Create.Single dto,
+    public Result post(@Valid @RequestBody Single dto,
         Authentication authentication) {
         return service.create(dto, authentication);
     }
@@ -69,7 +68,7 @@ public class SubIngredientController {
 
     @PostMapping("/post/recipe/bulk-subIngredient")
     @ResponseStatus(HttpStatus.CREATED)
-    public Bulk.Result bulkCreate(@Valid @RequestBody SubIngredientDto.Bulk.Create.Single bulkDto,
+    public Bulk.Result bulkCreate(@Valid @RequestBody Bulk.Create.Single bulkDto,
         Authentication authentication) {
         return service.bulkCreate(bulkDto, authentication);
     }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -1,6 +1,7 @@
 package kr.reciptopia.reciptopiaserver.domain.dto;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.helper.InitializationHelper.noInit;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,7 @@ public interface SubIngredientDto {
                 public WithRecipe(
                     @NotEmpty
                     @Singular
-                        List<SubIngredientDto.Create.WithRecipe> subIngredients
+                    List<SubIngredientDto.Create.WithRecipe> subIngredients
                 ) {
                     this.subIngredients = subIngredients;
                 }
@@ -57,7 +58,7 @@ public interface SubIngredientDto {
                 public Single(
                     @NotEmpty
                     @Singular
-                        List<SubIngredientDto.Create.Single> subIngredients
+                    List<SubIngredientDto.Create.Single> subIngredients
                 ) {
                     this.subIngredients = subIngredients;
                 }
@@ -79,7 +80,7 @@ public interface SubIngredientDto {
             public Update(
                 @NotEmpty
                 @Singular
-                    Map<Long, SubIngredientDto.Update> subIngredients
+                Map<Long, SubIngredientDto.Update> subIngredients
             ) {
                 this.subIngredients = subIngredients;
             }
@@ -94,7 +95,7 @@ public interface SubIngredientDto {
             public Result(
                 @NotEmpty
                 @Singular
-                    Map<Long, SubIngredientDto.Result> subIngredients
+                Map<Long, SubIngredientDto.Result> subIngredients
             ) {
                 this.subIngredients = subIngredients;
             }
@@ -170,31 +171,17 @@ public interface SubIngredientDto {
         @Size(min = 1, max = 20, message = "name은 1 ~ 20자 이여야 합니다!") String name,
         @Size(min = 1, max = 50, message = "detail은 1 ~ 50자 이여야 합니다!") String detail
     ) {
+
     }
 
     @With
+    @Builder
     record Result(
-        Long id, Long recipeId, String name, String detail
+        @NotNull Long id,
+        @NotNull Long recipeId,
+        @NotBlank @Size(min = 1, max = 20, message = "name은 1 ~ 20자 이여야 합니다!") String name,
+        @NotBlank @Size(min = 1, max = 50, message = "detail은 1 ~ 50자 이여야 합니다!") String detail
     ) {
-
-        @Builder
-        public Result(
-            @NotNull
-                Long id,
-
-            @NotNull
-                Long recipeId,
-
-            @NotEmpty
-                String name,
-
-            @NotEmpty
-                String detail) {
-            this.id = id;
-            this.recipeId = recipeId;
-            this.name = name;
-            this.detail = detail;
-        }
 
         public static Result of(SubIngredient entity) {
             return Result.builder()

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -51,12 +51,11 @@ public interface SubIngredientDto {
 
             @With
             record Single(
-                List<SubIngredientDto.Create.Single> subIngredients
+                @NotEmpty List<SubIngredientDto.Create.Single> subIngredients
             ) {
 
                 @Builder
                 public Single(
-                    @NotEmpty
                     @Singular
                     List<SubIngredientDto.Create.Single> subIngredients
                 ) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -26,12 +26,11 @@ public interface SubIngredientDto {
         interface Create {
 
             record WithRecipe(
-                List<SubIngredientDto.Create.WithRecipe> subIngredients
+                @NotEmpty List<SubIngredientDto.Create.WithRecipe> subIngredients
             ) {
 
                 @Builder
                 public WithRecipe(
-                    @NotEmpty
                     @Singular
                     List<SubIngredientDto.Create.WithRecipe> subIngredients
                 ) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -88,12 +88,11 @@ public interface SubIngredientDto {
 
         @With
         record Result(
-            Map<Long, SubIngredientDto.Result> subIngredients
+            @NotEmpty Map<Long, SubIngredientDto.Result> subIngredients
         ) {
 
             @Builder
             public Result(
-                @NotEmpty
                 @Singular
                 Map<Long, SubIngredientDto.Result> subIngredients
             ) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -165,13 +165,11 @@ public interface SubIngredientDto {
     }
 
     @With
+    @Builder
     record Update(
-        String name, String detail
+        @Size(min = 1, max = 20, message = "name은 1 ~ 20자 이여야 합니다!") String name,
+        @Size(min = 1, max = 50, message = "detail은 1 ~ 50자 이여야 합니다!") String detail
     ) {
-
-        @Builder
-        public Update {
-        }
     }
 
     @With

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -1,7 +1,6 @@
 package kr.reciptopia.reciptopiaserver.domain.dto;
 
 import static kr.reciptopia.reciptopiaserver.domain.dto.helper.InitializationHelper.noInit;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -170,15 +169,6 @@ public interface SubIngredientDto {
 
             public SubIngredient asEntity() {
                 return asEntity(noInit());
-            }
-
-            public Single withRecipeId(Long recipeId) {
-                return this.recipeId != null && this.recipeId.equals(recipeId) ? this
-                    : Single.builder()
-                        .recipeId(recipeId)
-                        .name(name)
-                        .detail(detail)
-                        .build();
             }
 
         }

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -37,12 +37,12 @@ public interface SubIngredientDto {
                     this.subIngredients = subIngredients;
                 }
 
-                public SubIngredientDto.Bulk.Create.Single asSingleDto(
+                public Bulk.Create.Single asSingleDto(
                     Function<? super SubIngredientDto.Create.Single, ? extends SubIngredientDto.Create.Single> initialize) {
                     List<SubIngredientDto.Create.Single> singleDtos = this.subIngredients.stream()
                         .map(m -> m.asSingleDto(initialize))
                         .collect(Collectors.toList());
-                    return SubIngredientDto.Bulk.Create.Single.builder()
+                    return Bulk.Create.Single.builder()
                         .subIngredients(singleDtos)
                         .build();
                 }
@@ -124,17 +124,17 @@ public interface SubIngredientDto {
             public WithRecipe(
 
                 @NotEmpty
-                    String name,
+                String name,
 
                 @NotEmpty
-                    String detail) {
+                String detail) {
                 this.name = name;
                 this.detail = detail;
             }
 
-            public SubIngredientDto.Create.Single asSingleDto(
-                Function<? super SubIngredientDto.Create.Single, ? extends SubIngredientDto.Create.Single> initialize) {
-                return initialize.apply(SubIngredientDto.Create.Single.builder()
+            public Create.Single asSingleDto(
+                Function<? super Create.Single, ? extends Create.Single> initialize) {
+                return initialize.apply(Create.Single.builder()
                     .name(name)
                     .detail(detail)
                     .build());

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -73,12 +73,11 @@ public interface SubIngredientDto {
 
         @With
         record Update(
-            Map<Long, SubIngredientDto.Update> subIngredients
+            @NotEmpty Map<Long, SubIngredientDto.Update> subIngredients
         ) {
 
             @Builder
             public Update(
-                @NotEmpty
                 @Singular
                 Map<Long, SubIngredientDto.Update> subIngredients
             ) {

--- a/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
+++ b/src/main/java/kr/reciptopia/reciptopiaserver/domain/dto/SubIngredientDto.java
@@ -7,8 +7,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import kr.reciptopia.reciptopiaserver.domain.model.SubIngredient;
 import lombok.Builder;
 import lombok.Singular;
@@ -140,24 +142,12 @@ public interface SubIngredientDto {
         }
 
         @With
+        @Builder
         record Single(
-            Long recipeId, String name, String detail
+            @NotNull Long recipeId,
+            @NotBlank @Size(min = 1, max = 20, message = "name은 1 ~ 20자 이여야 합니다!") String name,
+            @NotBlank @Size(min = 1, max = 50, message = "detail은 1 ~ 50자 이여야 합니다!") String detail
         ) {
-
-            @Builder
-            public Single(
-                @NotNull
-                    Long recipeId,
-
-                @NotEmpty
-                    String name,
-
-                @NotEmpty
-                    String detail) {
-                this.recipeId = recipeId;
-                this.name = name;
-                this.detail = detail;
-            }
 
             public SubIngredient asEntity(
                 Function<? super SubIngredient, ? extends SubIngredient> initialize) {

--- a/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
@@ -705,6 +705,143 @@ public class SubIngredientIntegrationTest {
             actions
                 .andExpect(status().isNotFound());
         }
+
+        @Test
+        void white_space_들로_채워진_name으로_subIngredient_수정() throws Exception {
+
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                SubIngredient subIngredient = entityHelper.generateSubIngredient();
+
+                String token = ingredientAuthHelper.generateToken(subIngredient);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("id", subIngredient.getId())
+                    .withValue("recipeId", subIngredient.getRecipe().getId());
+            });
+            String token = given.valueOf("token");
+            Long id = given.valueOf("id");
+
+            // When
+            Update dto = Update.builder()
+                .name("         ")
+                .detail("20g")
+                .build();
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(patch("/post/recipe/subIngredients/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 너무_긴_길이의_name으로_subIngredient_수정() throws Exception {
+
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                SubIngredient subIngredient = entityHelper.generateSubIngredient();
+
+                String token = ingredientAuthHelper.generateToken(subIngredient);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("id", subIngredient.getId())
+                    .withValue("recipeId", subIngredient.getRecipe().getId());
+            });
+            String token = given.valueOf("token");
+            Long id = given.valueOf("id");
+
+            // When
+            Update dto = Update.builder()
+                .name(
+                    "압력밥솥에 물 2000ml정도와 한방팩, 대추, 마늘, 과 같이 뚜껑을 잘 닫은 뒤 "
+                        + "센불에서 끓여 주시다가 추가 움직이기 시작하면 중불로 낮춰 10분간 삶아주고 "
+                        + "바로 김을 빼준뒤 꺼낸 닭에 뿌릴 고추장")
+                .detail("20g")
+                .build();
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(patch("/post/recipe/subIngredients/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void white_space_들로_채워진_detail로_subIngredient_수정() throws Exception {
+
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                SubIngredient subIngredient = entityHelper.generateSubIngredient();
+
+                String token = ingredientAuthHelper.generateToken(subIngredient);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("id", subIngredient.getId())
+                    .withValue("recipeId", subIngredient.getRecipe().getId());
+            });
+            String token = given.valueOf("token");
+            Long id = given.valueOf("id");
+
+            // When
+            Update dto = Update.builder()
+                .name("불고기 고추장")
+                .detail("         ")
+                .build();
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(patch("/post/recipe/subIngredients/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 너무_긴_길이의_detail로_subIngredient_수정() throws Exception {
+
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                SubIngredient subIngredient = entityHelper.generateSubIngredient();
+
+                String token = ingredientAuthHelper.generateToken(subIngredient);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("id", subIngredient.getId())
+                    .withValue("recipeId", subIngredient.getRecipe().getId());
+            });
+            String token = given.valueOf("token");
+            Long id = given.valueOf("id");
+
+            // When
+            Update dto = Update.builder()
+                .name("불고기 고추장")
+                .detail(
+                    "불고기 조각1/4컵, 고춧가루1/4컵, 겨자조금, 간장2T, 식초2T, "
+                        + "설탕1/3T, 다진마늘1T 과 대파 약간을 잘 섞어서만든 고추장 소스 20g")
+                .build();
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(patch("/post/recipe/subIngredients/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
     }
 
     @Nested

--- a/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
@@ -979,6 +979,32 @@ public class SubIngredientIntegrationTest {
                     .andExpect(status().isForbidden())
                     .andReturn();
             }
+
+            @Test
+            void subIngredients가_없는_subIngredient_다중_생성() throws Exception {
+                // Given
+                Struct given = trxHelper.doInTransaction(() -> {
+                    Recipe recipe = entityHelper.generateRecipe();
+                    String token = ingredientAuthHelper.generateToken(recipe);
+                    return new Struct()
+                        .withValue("token", token);
+                });
+                String token = given.valueOf("token");
+
+                // When
+                Bulk.Create.Single dto = tripleSubIngredientsBulkCreateDto()
+                    .withSubIngredients(null);
+                String body = jsonHelper.toJson(dto);
+
+                ResultActions actions = mockMvc.perform(post("/post/recipe/bulk-subIngredient")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + token)
+                    .content(body));
+
+                // Then
+                actions
+                    .andExpect(status().isBadRequest());
+            }
         }
 
         @Nested

--- a/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
@@ -26,7 +26,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import kr.reciptopia.reciptopiaserver.docs.ApiDocumentation;
@@ -134,7 +133,7 @@ public class SubIngredientIntegrationTest {
             String token = given.valueOf("token");
 
             // When
-            Single dto = kr.reciptopia.reciptopiaserver.domain.dto.SubIngredientDto.Create.Single.builder()
+            Single dto = Single.builder()
                 .recipeId(recipeId)
                 .name("간장")
                 .detail("한 큰술")

--- a/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
+++ b/src/test/java/kr/reciptopia/reciptopiaserver/SubIngredientIntegrationTest.java
@@ -176,6 +176,302 @@ public class SubIngredientIntegrationTest {
             actions
                 .andExpect(status().isNotFound());
         }
+
+        @Test
+        void recipe_id가_없는_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token);
+            });
+            String token = given.valueOf("token");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(null);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 존재하지않는_recipe_id로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token);
+            });
+            String token = given.valueOf("token");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(-1L);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void token이_없는_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                return new Struct()
+                    .withValue("recipeId", recipe.getId());
+            });
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId);
+
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void 권한이_없는_recipe_id로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipeA = entityHelper.generateRecipe();
+                Recipe recipeB = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipeA);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeAId", recipeA.getId())
+                    .withValue("recipeBId", recipeB.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeBId = given.valueOf("recipeBId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeBId);
+
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void name이_없는_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withName(null);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 공백으로_채워진_name으로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withName("      ");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 너무_긴_길이의_name으로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withName("And_so_I_wake_in_the_morning_and_I_step_Outside_"
+                    + "and_I_take_a_deep_breath_And_I_get_real_high_"
+                    + "Then_I_scream_from_the_top_of_my_lungs_What's_goin_on");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void detail이_없는_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withDetail(null);
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 공백으로_채워진_detail로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withDetail("      ");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        void 너무_긴_길이의_detail로_sub_ingredient_생성() throws Exception {
+            // Given
+            Struct given = trxHelper.doInTransaction(() -> {
+                Recipe recipe = entityHelper.generateRecipe();
+
+                String token = ingredientAuthHelper.generateToken(recipe);
+                return new Struct()
+                    .withValue("token", token)
+                    .withValue("recipeId", recipe.getId());
+            });
+            String token = given.valueOf("token");
+            Long recipeId = given.valueOf("recipeId");
+
+            // When
+            Single dto = aSubIngredientCreateDto()
+                .withRecipeId(recipeId)
+                .withDetail("And_so_I_wake_in_the_morning_and_I_step_Outside_"
+                    + "and_I_take_a_deep_breath_And_I_get_real_high_"
+                    + "Then_I_scream_from_the_top_of_my_lungs_What's_goin_on");
+            String body = jsonHelper.toJson(dto);
+
+            ResultActions actions = mockMvc.perform(post("/post/recipe/subIngredients")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(body));
+
+            // Then
+            actions
+                .andExpect(status().isBadRequest());
+        }
     }
 
     @Nested


### PR DESCRIPTION
# ✅ Checklist


- [x] Set Projects

- [x] Set Labels

---

# 📕 Task


- [x] SubIngredientDto  Bean Validation 수정

- [x] SubIngredientDto Builder 애노테이션 수정 및 생성자 수정 

- [x] SubIngredientService 검증로직 추가

- [x] SubIngredient 통합 테스트 검증로직 추가

---

# 📝Memo


기존 `record` 에 적용되어 있었던  `Bean Validation` 이 적절하지 못한 위치에서 선언되어 

해당 `Bean Validation`  이 적용되지 않고 있었던 버그 수정을 위한 리펙토링과

해당 `Bean Validation`  에 대한 검증로직 추가


또한 `Bean Validation` 의 위치가 변경됨에 따라 

DTO의 생성자를 Compact 하게 만들 수 있고, 해당 생성자를 생략함으로써

Builder 애노테이션의 위치를 수정


`update DTO` 의 특성상 해당 필드가

수정하지 않는 필드일 경우 null 값이 들어가게 되므로

null 이 아닐때 빈 공백으로 이루어져 있는지

검사하는 로직이 별도록 필요하여

해당 로직을 Service 계층에 추가

그러나 해당 로직은 타 엔티티의 검증요소가

추가됨에따라 코드 중복의 우려가 있으므로

추후 리펙토링 예정